### PR TITLE
allows proper R_path lookup in registry

### DIFF
--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -547,7 +547,7 @@ local windows_config = function()
             return rip
         end
 
-        local run_cmd = { "reg.exe", "QUERY", "HKLM\\SOFTWARE\\R-core\\R", "/s" }
+        local run_cmd = { "reg.exe", "QUERY", "HKCU\\SOFTWARE\\R-core\\R", "/s" }
         local rip = get_rip(run_cmd)
         if #rip == 0 then
             -- Normally, 32 bit applications access only 32 bit registry and...


### PR DESCRIPTION
Fixes issue [#43](https://github.com/R-nvim/R.nvim/issues/43) from yesterday! Error message goes away and doesn't seem impact any other functionality. 