### PR TITLE
Fix single line Shift+V send

### DIFF
--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -377,21 +377,6 @@ M.selection = function(m)
     local lines = vim.api.nvim_buf_get_lines(0, start_pos[1] - 1, end_pos[1], true)
 
     local vmode = vim.fn.visualmode()
-    if vmode == "V" then
-        local ok = M.source_lines(lines, "selection")
-        if ok and m == true then cursor.move_next_line() end
-        return
-    end
-
-    if start_pos[1] == end_pos[1] then
-        local line = lines[1]
-        line = string.sub(line, start_pos[2] + 1, end_pos[2] + 1)
-        if vim.o.filetype == "r" then line = cursor.clean_oxygen_line(line) end
-        local ok = M.cmd(line)
-        if ok and m == true then cursor.move_next_line() end
-        return
-    end
-
     if vmode == "\022" then
         -- "\022" is <C-V>
         local cj = start_pos[2] + 1
@@ -405,9 +390,13 @@ M.selection = function(m)
             lines[k] = string.sub(lines[k], cj, ck)
         end
     elseif vmode == "v" then
-        lines[1] = string.sub(lines[1], start_pos[2] + 1, -1)
-        local llen = #lines
-        lines[llen] = string.sub(lines[llen], 1, end_pos[2] + 1)
+        if start_pos[1] == end_pos[1] then
+            lines[1] = string.sub(lines[1], start_pos[2] + 1, end_pos[2] + 1)
+        else
+            lines[1] = string.sub(lines[1], start_pos[2] + 1, -1)
+            local llen = #lines
+            lines[llen] = string.sub(lines[llen], 1, end_pos[2] + 1)
+        end
     end
 
     if vim.o.filetype == "r" then

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -376,6 +376,13 @@ M.selection = function(m)
     local end_pos = vim.api.nvim_buf_get_mark(0, ">")
     local lines = vim.api.nvim_buf_get_lines(0, start_pos[1] - 1, end_pos[1], true)
 
+    local vmode = vim.fn.visualmode()
+    if vmode == "V" then
+        local ok = M.source_lines(lines, "selection")
+        if ok and m == true then cursor.move_next_line() end
+        return
+    end
+
     if start_pos[1] == end_pos[1] then
         local line = lines[1]
         line = string.sub(line, start_pos[2] + 1, end_pos[2] + 1)
@@ -385,7 +392,6 @@ M.selection = function(m)
         return
     end
 
-    local vmode = vim.fn.visualmode()
     if vmode == "\022" then
         -- "\022" is <C-V>
         local cj = start_pos[2] + 1


### PR DESCRIPTION
Doing a line-wise visual  `Shift+V` and `RSendSelection` (or `:lua require('r.send').selection(false)`) on a single line is currently broken. I think this is because it gets caught into this if statement, which does `+ 1` to the start and end column position to align it on line 381:

https://github.com/R-nvim/R.nvim/blob/c0dc42b1b197476e2ff9c85e68dbf5daf598d1d2/lua/r/send.lua#L379-L386

The problem comes because in line-wise visual mode the column index of `end_pos` is set to $2^{31} -1$, and you probably get some sort of overflow error when you add 1.

I'm not convinced my solution is best since it requires another if statement, but I thought it's better than nesting inside the if statement above. Good if someone could test this too and see if there's a neater solution.