### PR TITLE
Improve completion of methods arguments

### DIFF
--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -32,7 +32,6 @@ local config = {
     external_term       = false, -- might be a string
     has_X_tools         = false,
     help_w              = 46,
-    hi_fun_paren        = false,
     hl_term             = true,
     hook                = {
                               after_config = nil,
@@ -280,7 +279,7 @@ local do_common_global = function()
     -- Create or update the README (objls_ files will be regenerated if older than
     -- the README).
     local need_readme = false
-    local first_line = "Last change in this file: 2024-03-09"
+    local first_line = "Last change in this file: 2024-03-10"
     if
         vim.fn.filereadable(config.compldir .. "/README") == 0
         or vim.fn.readfile(config.compldir .. "/README")[1] ~= first_line

--- a/lua/r/edit.lua
+++ b/lua/r/edit.lua
@@ -49,7 +49,7 @@ M.add_for_deletion = function(fname)
 end
 
 M.vim_leave = function()
-    require("r.job").stop_nrs()
+    require("r.job").stop_rns()
 
     for _, fn in pairs(del_list) do
         vim.fn.delete(fn)

--- a/lua/r/job.lua
+++ b/lua/r/job.lua
@@ -182,7 +182,7 @@ M.is_running = function(job_name)
     return false
 end
 
-M.stop_nrs = function()
+M.stop_rns = function()
     for k, v in pairs(jobs) do
         if M.is_running(k) and k == "Server" then
             -- Avoid warning of exit status 141

--- a/lua/r/run.lua
+++ b/lua/r/run.lua
@@ -164,7 +164,7 @@ end
 
 --- Register rnvimserver port in a environment variable
 ---@param p string
-M.set_nrs_port = function(p)
+M.set_rns_port = function(p)
     vim.g.R_Nvim_status = 5
     vim.env.RNVIM_PORT = p
 end

--- a/nvimcom/DESCRIPTION
+++ b/nvimcom/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nvimcom
-Version: 0.9.29.3
-Date: 2024-03-09
+Version: 0.9.30
+Date: 2024-03-10
 Title: Intermediate the Communication Between R and Neovim
 Author: Jakson Aquino
 Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>

--- a/nvimcom/R/nvimcom.R
+++ b/nvimcom/R/nvimcom.R
@@ -1,5 +1,6 @@
 NvimcomEnv <- new.env()
 NvimcomEnv$pkgdescr <- list()
+NvimcomEnv$pkgRdDB <- list()
 
 #' Function called by R when nvimcom is being loaded.
 #' R.nvim creates environment variables and the start_options.R file to set

--- a/nvimcom/src/apps/data_structures.h
+++ b/nvimcom/src/apps/data_structures.h
@@ -33,7 +33,7 @@ ListStatus *search(ListStatus *root, const char *s);
 typedef struct pkg_data_ {
     char *name;    // The package name
     char *version; // The package version number
-    char *fname;   // Omnils_ file name in the compldir
+    char *fname;   // Objls_ file name in the compldir
     char *descr;   // The package short description
     char *objls;  // A copy of the objls_ file
     char *alias;  // A copy of the alias_ file

--- a/nvimcom/src/nvimcom.c
+++ b/nvimcom/src/nvimcom.c
@@ -41,7 +41,7 @@ static int allnames = 0; // Show hidden objects in auto completion and
                          // Object Browser?
 static int nlibs = 0;    // Number of loaded libraries.
 
-static char nrs_port[16]; // rnvimserver port.
+static char rns_port[16]; // rnvimserver port.
 static char nvimsecr[32]; // Random string used to increase the safety of TCP
                           // communication.
 
@@ -92,7 +92,7 @@ static int flag_glbenv = 0; // Do we have to list objects from .GlobalEnv?
  * @typedef lib_info_
  * @brief Structure with name and version number of a library.
  *
- * The complete information of libraries is stored in its `objls_`, `fun_` and
+ * The complete information of libraries is stored in its `objls_`, `alias_`, and
  * `args_` files in the R.nvim cache directory. The rnvimserver only needs the
  * name and version number of the library to read the corresponding files.
  *
@@ -234,7 +234,7 @@ static void send_to_nvim(char *msg) {
         close(sfd);
 #endif
         sfd = -1;
-        strcpy(nrs_port, "0");
+        strcpy(rns_port, "0");
         return;
     }
 
@@ -887,7 +887,7 @@ static Rboolean nvimcom_task(__attribute__((unused)) SEXP expr,
 #ifdef WIN32
     r_is_busy = 0;
 #endif
-    if (nrs_port[0] != 0) {
+    if (rns_port[0] != 0) {
         nvimcom_checklibs();
         if (autoglbenv)
             nvimcom_globalenv_list();
@@ -1183,7 +1183,7 @@ void nvimcom_Start(int *vrb, int *anm, int *swd, int *age, char **nvv,
     }
 
     if (getenv("RNVIM_PORT"))
-        strncpy(nrs_port, getenv("RNVIM_PORT"), 15);
+        strncpy(rns_port, getenv("RNVIM_PORT"), 15);
 
     if (verbose > 0)
         REprintf("nvimcom %s loaded\n", *nvv);
@@ -1192,7 +1192,7 @@ void nvimcom_Start(int *vrb, int *anm, int *swd, int *age, char **nvv,
             REprintf("  NVIM_IP_ADDRESS: %s\n", getenv("NVIM_IP_ADDRESS"));
         }
         REprintf("  CMPR_DOC_WIDTH: %s\n", getenv("CMPR_DOC_WIDTH"));
-        REprintf("  RNVIM_PORT: %s\n", nrs_port);
+        REprintf("  RNVIM_PORT: %s\n", rns_port);
         REprintf("  RNVIM_ID: %s\n", getenv("RNVIM_ID"));
         REprintf("  RNVIM_TMPDIR: %s\n", tmpdir);
         REprintf("  RNVIM_COMPLDIR: %s\n", getenv("RNVIM_COMPLDIR"));
@@ -1221,7 +1221,7 @@ void nvimcom_Start(int *vrb, int *anm, int *swd, int *age, char **nvv,
 
     static int failure = 0;
 
-    if (atoi(nrs_port) > 0) {
+    if (atoi(rns_port) > 0) {
         struct sockaddr_in servaddr;
 #ifdef WIN32
         WSADATA d;
@@ -1241,7 +1241,7 @@ void nvimcom_Start(int *vrb, int *anm, int *swd, int *age, char **nvv,
                 servaddr.sin_addr.s_addr = inet_addr(getenv("NVIM_IP_ADDRESS"));
             else
                 servaddr.sin_addr.s_addr = inet_addr("127.0.0.1");
-            servaddr.sin_port = htons(atoi(nrs_port));
+            servaddr.sin_port = htons(atoi(rns_port));
 
             // connect the client socket to server socket
             if (connect(sfd, (struct sockaddr *)&servaddr, sizeof(servaddr)) ==
@@ -1258,11 +1258,11 @@ void nvimcom_Start(int *vrb, int *anm, int *swd, int *age, char **nvv,
 #endif
             } else {
                 REprintf("nvimcom: connection with the server failed (%s)\n",
-                         nrs_port);
+                         rns_port);
                 failure = 1;
             }
         } else {
-            REprintf("nvimcom: socket creation failed (%d)\n", atoi(nrs_port));
+            REprintf("nvimcom: socket creation failed (%d)\n", atoi(rns_port));
             failure = 1;
         }
     }

--- a/nvimcom/src/rd2md.c
+++ b/nvimcom/src/rd2md.c
@@ -1,9 +1,5 @@
 #include <R.h>
 #include <Rdefines.h>
-#include <Rinternals.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include "common.h"
 
 typedef struct pattern {
@@ -33,7 +29,7 @@ typedef struct pattern {
 // packages : \code (1814), \R (220), \emph (97), sQuote (76), \eqn (59),
 // \dQuote (41), \link (30), \pkg (29) etc...
 static struct pattern rd[] = {
-    // Optimized for default R 4.2.2 packages
+    // Order optimized for default R 4.2.2 packages
     {"code", 4, 8, "`", "`"},
     {"R", 1, 0, "*R*", "\000"},
     {"emph", 4, 1, "*", "*"},
@@ -410,7 +406,7 @@ SEXP rd2md(SEXP txt) {
     p1 = a;
     p2 = b;
     // Skip leading empty spaces:
-    while (p1 && (*p1 == ' ' || *p1 == '\n' || *p1 == '\t' || *p1 == '\r'))
+    while (*p1 && (*p1 == ' ' || *p1 == '\n' || *p1 == '\t' || *p1 == '\r'))
         p1++;
     while (*p1) {
         if (p1[0] && p1[1] && p1[2] && p1[0] == '`' && p1[1] == '`' &&
@@ -448,8 +444,8 @@ SEXP rd2md(SEXP txt) {
                 *p2 = ' ';
                 p2++;
                 p1++;
-                // - Replace two or more empty spaces with a single one
-                while (p1 && (*p1 == ' ' || *p1 == '\n'))
+                // - Skip the second and following spaces
+                while (*p1 && (*p1 == ' ' || *p1 == '\n'))
                     p1++;
             } else {
                 *p2 = *p1;
@@ -462,7 +458,7 @@ SEXP rd2md(SEXP txt) {
 
     // Delete trailing spaces
     p2--;
-    while (p2 && (*p2 == ' ' || *p2 == '\x14')) {
+    while (*p2 && (*p2 == ' ' || *p2 == '\x14')) {
         *p2 = 0;
         p2--;
     }
@@ -491,6 +487,7 @@ SEXP get_section(SEXP rtxt, SEXP rsec) {
 
     const char *str = CHAR(STRING_ELT(rtxt, 0));
     const char *sec = CHAR(STRING_ELT(rsec, 0));
+
     char *a = calloc(sizeof(char), (strlen(str) + 1));
     char *b = malloc(sizeof(char) * (strlen(str) + 1));
     strcpy(b, str);

--- a/scripts/before_rns.R
+++ b/scripts/before_rns.R
@@ -1,3 +1,5 @@
+libs <- libs[libs != ""]
+
 # R may break strings while sending them even if they are short
 out <- function(x) {
     # R.nvim will wait for more input if the string doesn't end with "\x14"
@@ -144,8 +146,7 @@ if (length(np) == 1) {
     nvimcom_info <- c(nd$Version, np, sub("R ([^;]*).*", "\\1", nd$Built))
     writeLines(nvimcom_info, paste0(Sys.getenv("RNVIM_COMPLDIR"), "/nvimcom_info"))
 
-    # Build objls_, fun_ and args_ files, if necessary
-    library("nvimcom", warn.conflicts = FALSE)
+    # Save lib names for rnvimserver
     hasl <- rep(FALSE, length(libs))
     lver <- rep("", length(libs))
     for (i in 1:length(libs))
@@ -157,8 +158,6 @@ if (length(np) == 1) {
     lver <- lver[hasl]
     cat(paste(libs, lver, collapse = '\n', sep = '_'),
         '\n', sep = '', file = paste0(Sys.getenv("RNVIM_TMPDIR"), "/libnames_", Sys.getenv("RNVIM_ID")))
-    if (nvimcom:::nvim.build.cmplls(libs) > 0)
-        out("ECHO:  ")
     quit(save = "no")
 }
 


### PR DESCRIPTION
- Look for methods for second and following classes in objects with multiple classes.
- Always run code to build completion data as a Neovim job.
- Build the `args_` file right after building the corresponding `objls_` file.
- Add time to build `objls_` + `args_` to `:RDebugInfo`.