### PR TITLE
Send some preceding lines to the console

### DIFF
--- a/lua/r/cursor.lua
+++ b/lua/r/cursor.lua
@@ -70,7 +70,7 @@ M.move_next_line = function()
         if filetype == "rnoweb" and string.sub(curline, 1, 1) == "@" then
             require("r.rnw").next_chunk()
             return
-        elseif (filetype == "rmd" or filetype == "quarto") and curline:find("^```$") then
+        elseif (filetype == "rmd" or filetype == "quarto") and curline:find("^```$") ~= nil then
             require("r.rmd").next_chunk()
             return
         end

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -92,9 +92,7 @@ local function get_code_to_send(txt, row)
         ["program"] = true,
         ["brace_list"] = true,
     }
-    local is_root = function(n)
-        return root_nodes[n:type()] == true
-    end
+    local is_root = function(n) return root_nodes[n:type()] == true end
 
     while true do
         local parent = node:parent()

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -31,7 +31,7 @@ local ensure_ts_parser_exists = function(txt, row)
         chunk_end_pattern = chunk_start_pattern
     elseif vim.o.filetype == "rnoweb" then
         chunk_start_pattern = "^<<"
-        chunk_end_pattern = "@"
+        chunk_end_pattern = "^@"
     else
         return
     end
@@ -84,16 +84,16 @@ local function get_code_to_send(txt, row)
         bufnr = 0,
         pos = { row - 1, col - 1 },
         lang = "r",
-        -- Required for quart/rmd/rnoweb where we need to inject a parser
+        -- Required for quarto/rmd/rnoweb where we need to inject a parser
         ignore_injections = vim.o.filetype == "r",
     })
 
+    local root_nodes = {
+        ["program"] = true,
+        ["brace_list"] = true,
+    }
     local is_root = function(n)
-        local terminating_nodes = {
-            ["program"] = true,
-            ["brace_list"] = true,
-        }
-        return terminating_nodes[n:type()] == true
+        return root_nodes[n:type()] == true
     end
 
     while true do

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -5,21 +5,35 @@ local edit = require("r.edit")
 local cursor = require("r.cursor")
 local paragraph = require("r.paragraph")
 
-
 --- Check if line ends with operator symbol
 ---@param line string
 ---@return boolean
 local ends_with_operator = function(line)
     local op_patterns = {
-        "&", "|", "!", "+", "-", "%^", "%*", "%/", "%=", "~", "%-", "%<", "%>",
-        "%?", "%%", ":", "@", "%$", "%["
+        "&",
+        "|",
+        "!",
+        "+",
+        "-",
+        "%^",
+        "%*",
+        "%/",
+        "%=",
+        "~",
+        "%-",
+        "%<",
+        "%>",
+        "%?",
+        "%%",
+        ":",
+        "@",
+        "%$",
+        "%[",
     }
     local clnline = line:gsub("#.*", "")
 
     for _, v in pairs(op_patterns) do
-        if clnline:find(v .. "%s*$") then
-            return true
-        end
+        if clnline:find(v .. "%s*$") then return true end
     end
 
     return false
@@ -44,6 +58,11 @@ end
 ---@param line string
 ---@return boolean
 local is_comment = function(line) return line:find("^%s*#") ~= nil end
+
+--- Check if a line is blank
+--- @param line string
+--- @return boolean
+local is_blank = function(line) return line:find("^%s*$") ~= nil end
 
 local M = {}
 
@@ -527,7 +546,7 @@ M.line = function(m, lnum)
         while lnum_prev > 0 do
             lnum_prev = lnum_prev - 1
             local txt = vim.fn.getline(lnum_prev)
-            if is_comment(txt) then
+            if is_comment(txt) or is_blank(txt) then
                 table.insert(lines, 1, txt)
             else
                 if chunkstart and txt:find("^" .. chunkstart) ~= nil then break end
@@ -550,7 +569,7 @@ M.line = function(m, lnum)
                 local txt = vim.fn.getline(lnum)
                 if chunkend and txt == chunkend then break end
                 table.insert(lines, txt)
-                if is_comment(txt) then
+                if is_comment(txt) or is_blank(txt) then
                     lnum = lnum + 1
                 else
                     rpd = rpd + paren_diff(txt)

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -5,20 +5,24 @@ local edit = require("r.edit")
 local cursor = require("r.cursor")
 local paragraph = require("r.paragraph")
 
+
 --- Check if line ends with operator symbol
 ---@param line string
 ---@return boolean
 local ends_with_operator = function(line)
-    local op_pattern = { "&", "|", "+", "-", "%*", "%/", "%=", "~", "%-", "%<", "%>" }
+    local op_patterns = {
+        "&", "|", "!", "+", "-", "%^", "%*", "%/", "%=", "~", "%-", "%<", "%>",
+        "%?", "%%", ":", "@", "%$", "%["
+    }
     local clnline = line:gsub("#.*", "")
-    local has_op = false
-    for _, v in pairs(op_pattern) do
+
+    for _, v in pairs(op_patterns) do
         if clnline:find(v .. "%s*$") then
-            has_op = true
-            break
+            return true
         end
     end
-    return has_op
+
+    return false
 end
 
 --- Check if the number of brackets are balanced

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -578,7 +578,7 @@ M.line = function(m, lnum)
     if m == true then
         local last_line = vim.api.nvim_buf_line_count(0)
         -- Move to the last line of the sent expression
-        vim.api.nvim_win_set_cursor(0, { math.min(lnum + 2, last_line), 0 })
+        vim.api.nvim_win_set_cursor(0, { math.min(lnum + 1, last_line), 0 })
         -- Move to the start of the next expression
         -- Should this be changed to move you to the start of the next comment,
         -- now that sending from that location will also cause the next bit


### PR DESCRIPTION
For example, hitting `<CR>` with the cursor on the second line here, all 3 lines will now be sent to the console:

``` r
iris |>
  subset(Species == "setosa") |>
  transform(Sepal.Area = Sepal.Length * Sepal.Width)
```
The previous behaviour in this case was that only lines 2 and 3 would be sent, so you'd either have to go back to line 1 and re-send, or select all 3 lines before sending in visual mode. 

This also works in the case of mismatched parentheses. For example, hitting `<CR>` with the cursor on the second line here will now cause both lines to be sent:
``` r
(
123)
```

The new behaviour mimics RStudio, which feels more seamless to me.

I've tested in both R scripts and Quarto. 

I haven't tested with rnoweb. I understand R chunks in noweb are delimited at the start by lines like `<<my-chunk>>`, so when looking for the start of a noweb chunk I've just tested for lines beginning with `<<`.