### PR TITLE
Better hadling poissible nil values when using treesitter to send R code to the console (#99)

### DIFF
--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -52,7 +52,7 @@ local ensure_ts_parser_exists = function(txt, row)
         chunk_end_row = chunk_end_row + 1
     end
 
-    vim.treesitter.get_parser(0, "r"):parse(chunk_start_row, chunk_end_row)
+    vim.treesitter.get_parser(0, "r"):parse({ chunk_start_row, chunk_end_row })
 end
 
 --- Get the full expression the cursor is currently on
@@ -94,15 +94,19 @@ local function get_code_to_send(txt, row)
     }
     local is_root = function(n) return root_nodes[n:type()] == true end
 
-    while true do
-        local parent = node:parent()
-        if is_root(parent) then break end
-        node = parent
+    if node ~= nil then
+        while true do
+            local parent = node:parent()
+            if is_root(parent) then break end
+            node = parent
+        end
     end
 
-    row = node:end_()
+    if node then
+        row = node:end_()
+        table.insert(lines, vim.treesitter.get_node_text(node, 0))
+    end
 
-    table.insert(lines, vim.treesitter.get_node_text(node, 0))
     return lines, row
 end
 


### PR DESCRIPTION
🐛 (send.lua): Fix bug where vim.treesitter.get_parser was not receiving an array as argument

♻️ (send.lua): Refactor get_code_to_send function to add nil checks for node variable to prevent potential null reference errors

See #99 for reference.
