### PR TITLE
Support namespace prefix in `nvim.print()`

### DIFF
--- a/nvimcom/DESCRIPTION
+++ b/nvimcom/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nvimcom
-Version: 0.9.39
-Date: 2024-03-21
+Version: 0.9.40
+Date: 2024-04-01
 Title: Intermediate the Communication Between R and Neovim
 Author: Jakson Aquino
 Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>

--- a/nvimcom/R/print.R
+++ b/nvimcom/R/print.R
@@ -1,28 +1,48 @@
 #' Command sent to R console after `\rp`.
 #' @param object Object under cursor.
-#' @param firstobj If `object` is a function, the the first function parameter.
+#' @param firstobj If `object` is a function, the first function parameter.
 nvim.print <- function(object, firstobj) {
-    if (!exists(object))
+    # detect if object is a function with namespace prefix
+    exp <- parse(text = object, keep.source = FALSE)[[1L]]
+    if (has_ns <- is.call(exp) && deparse(exp[[1L]], nlines = 1L) %in% c("::", ":::")) {
+        ns <- asNamespace(exp[[2L]])
+        object <- deparse(exp[[3L]])
+    } else {
+        # use the default 'where' for 'exists()'
+        ns <- -1L
+    }
+
+    if (!exists(object, ns))
         warning("object '", object, "' not found")
     if (!missing(firstobj)) {
-        objclass <- nvim.getclass(firstobj)
+        objclass <- nvimcom:::nvim.getclass(firstobj)
         if (objclass[1] != "#E#" && objclass[1] != "") {
             saved.warn <- getOption("warn")
             options(warn = -1)
             on.exit(options(warn = saved.warn))
-            mlen <- try(length(methods(object)), silent = TRUE)
+
+            # `utils::methods()` only search in the search list, which means
+            # only packages that have been loaded are considered. In order to
+            # accept specified namespace, we need to set `mlen` here
+            if (has_ns) {
+                mlen <- 1L
+            } else {
+                mlen <- try(length(methods(object)), silent = TRUE)
+            }
+
             if (class(mlen)[1] == "integer" && mlen > 0) {
                 for (cls in objclass) {
-                    if (exists(paste0(object, ".", objclass))) {
-                        .newobj <- get(paste0(object, ".", objclass))
-                        message(paste0("Note: Printing ", object, ".", objclass))
+                    if (exists(paste0(object, ".", cls), ns)) {
+                        .newobj <- get(paste0(object, ".", cls), ns)
+                        message(paste0("Note: Printing ", object, ".", cls))
                         break
                     }
                 }
             }
         }
     }
-    if (!exists(".newobj"))
-        .newobj <- get(object)
+    # make sure only search current calling environment
+    if (!exists(".newobj", inherits = FALSE))
+        .newobj <- get(object, ns)
     print(.newobj)
 }

--- a/nvimcom/R/print.R
+++ b/nvimcom/R/print.R
@@ -15,7 +15,7 @@ nvim.print <- function(object, firstobj) {
     if (!exists(object, ns))
         warning("object '", object, "' not found")
     if (!missing(firstobj)) {
-        objclass <- nvimcom:::nvim.getclass(firstobj)
+        objclass <- nvim.getclass(firstobj)
         if (objclass[1] != "#E#" && objclass[1] != "") {
             saved.warn <- getOption("warn")
             options(warn = -1)


### PR DESCRIPTION
### Pull request overview

Currently, `nvimcom::nvim.print()` does not support functions with namespace, e.g.:

```r
dplyr::filter(mtcars, mpg > 20)
           ^--- cursor here
 
> nvim.print("dplyr::filter", "mtcars")
Error in get(object) : object 'dplyr::filter' not found
In addition: Warning message:
In nvim.print("dplyr::filter", "mtcars") : object 'dplyr::filter' not found
```

This PR fixes this, besides other enhancements, including:

- Correct the logic for searching S3 Methods, i.e. using `cls` in the for loop, instead of `objclass`
- Only detect `.newobj` in the enclosing environment