### PR TITLE
New feature: split file paths into its components

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,18 @@ It's important to note that both functions require
 the [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
 plugin to be installed.
 
+For example, if you have the following file path under the cursor:
+
+```r
+read.csv("/home/user/Documents/file.csv")
+```
+
+Running the <localleader>sp command will transform it into:
+
+```r
+read.csv(paste("/home", "user", "Documents", "file.csv", sep = "/"))
+```
+
 ## Screenshots and videos
 
 None yet. Tell us if you published a video presenting R.nvim features.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ instructions on usage. See also the output of `:RMapsDesc`.
 
 ## Transitioning from Nvim-R
 
-
 During the conversion of VimScript to Lua, we decided to end support for features
 that were useful in the past but no longer sufficiently valuable to be worth
 the effort of conversion. We removed support for `Rrst` (it seems that not
@@ -92,7 +91,7 @@ legacy omni-completion (auto completion with
 functions from .GlobalEnv (difficult to make compatible with tree-sitter + LSP
 highlighting).
 
-We changed the default key binding to insert the assignment operator (` <- `) from an
+We changed the default key binding to insert the assignment operator (`<-`) from an
 underscore (which was familiar to Emacs-ESS users) to `Alt+-` which is more
 convenient (but does not work on Vim). See the option `assign_map`.
 
@@ -140,6 +139,20 @@ function `colorout::isColorOut()` which unduly enables the colorizing of
 output in the released version of [colorout]. This bug was fixed in [this
 commit](https://github.com/jalvesaq/colorout/commit/1080187f9474b71f16c3c0be676de4c54863d1e7).
 
+There are two new commands available to separate a file path into its different
+components.
+
+The first command, <localleader>sp, will take the file path under
+the cursor and break it down into its components, then surround it with the
+`paste()` function.
+
+The second command, <localleader>sh, will also break down
+the file path under the cursor into its components, but instead surround it
+with the `here()` function.
+
+It's important to note that both functions require
+the [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
+plugin to be installed.
 
 ## Screenshots and videos
 
@@ -192,7 +205,6 @@ but temporary files are used in a few cases.
 - [languageserver](https://cran.r-project.org/web/packages/languageserver/index.html): a language server for R.
 
 - [colorout](https://github.com/jalvesaq/colorout): a package to colorize R's output.
-
 
 [cmp-r]: https://github.com/R-nvim/cmp-r
 [Neovim]: https://github.com/neovim/neovim

--- a/lua/r/maps.lua
+++ b/lua/r/maps.lua
@@ -16,6 +16,8 @@ local map_desc = {
     RViewDFv            = { m = "", k = "", c = "Edit",     d = "View the data.frame or matrix under cursor in a vertically split window" },
     RViewDFa            = { m = "", k = "", c = "Edit",     d = "View the head of a data.frame or matrix under cursor in a split window" },
     RShowEx             = { m = "", k = "", c = "Edit",     d = "Extract the Examples section and paste it in a split window" },
+    RSeparatePathPaste  = { m = "", k = "", c = "Edit",     d = "Split the path of the file under the cursor and paste it using the paste() prefix function" },
+    RSeparatePathHere   = { m = "", k = "", c = "Edit",     d = "Split the path of the file under the cursor and open it using the here() prefix function" },
     RNextRChunk         = { m = "", k = "", c = "Navigate", d = "Go to the next chunk of R code" },
     RGoToTeX            = { m = "", k = "", c = "Navigate", d = "Go the corresponding line in the generated LaTeX document" },
     RDocExSection       = { m = "", k = "", c = "Navigate", d = "Go to Examples section of R documentation" },
@@ -58,8 +60,6 @@ local map_desc = {
     RSetwd              = { m = "", k = "", c = "Command",  d = "Send to R setwd(<directory of current document>)" },
     RObjectStr          = { m = "", k = "", c = "Command",  d = "Send to R: str(<cword>)" },
     RSummary            = { m = "", k = "", c = "Command",  d = "Send to R: summary(<cword>)" },
-    RSplitPathPaste     = { m = "", k = "", c = "Command",  d = "Split the path of the file under the cursor and paste it using the paste() prefix function" },
-    RSplitPathHere      = { m = "", k = "", c = "Command",  d = "Split the path of the file under the cursor and open it using the here() prefix function" },
     RKnitRmCache        = { m = "", k = "", c = "Weave",    d = "Delete files from knitr cache" },
     RMakePDFKb          = { m = "", k = "", c = "Weave",    d = "Knit the current document and generate a beamer presentation" },
     RMakeAll            = { m = "", k = "", c = "Weave",    d = "Knit the current document and generate all formats in the header" },
@@ -139,8 +139,8 @@ local control = function(file_type)
     create_maps("v",   "RViewDF",           "rv", "<Cmd>lua require('r.run').action('viewobj', 'v')")
     create_maps("v",   "RDputObj",          "td", "<Cmd>lua require('r.run').action('dputtab', 'v')")
 
-    create_maps("nvi", "RSplitPathPaste",    "sp", "<Cmd>lua require('r.path').split_path('paste')")
-    create_maps("nvi", "RSplitPathHere",    "sh", "<Cmd>lua require('r.path').split_path('here')")
+    create_maps("nvi", "RSeparatePathPaste",    "sp", "<Cmd>lua require('r.path').separate('paste')")
+    create_maps("nvi", "RSeparatePathHere",    "sh", "<Cmd>lua require('r.path').separate('here')")
 
     if type(config.csv_app) == "function" or config.csv_app == "" then
         create_maps("ni",  "RViewDFs",          "vs", "<Cmd>lua require('r.run').action('viewobj', 'n', ', howto=\"split\"')")

--- a/lua/r/maps.lua
+++ b/lua/r/maps.lua
@@ -58,6 +58,8 @@ local map_desc = {
     RSetwd              = { m = "", k = "", c = "Command",  d = "Send to R setwd(<directory of current document>)" },
     RObjectStr          = { m = "", k = "", c = "Command",  d = "Send to R: str(<cword>)" },
     RSummary            = { m = "", k = "", c = "Command",  d = "Send to R: summary(<cword>)" },
+    RSplitPathPaste     = { m = "", k = "", c = "Command",  d = "Split the path of the file under the cursor and paste it using the paste() prefix function" },
+    RSplitPathHere      = { m = "", k = "", c = "Command",  d = "Split the path of the file under the cursor and open it using the here() prefix function" },
     RKnitRmCache        = { m = "", k = "", c = "Weave",    d = "Delete files from knitr cache" },
     RMakePDFKb          = { m = "", k = "", c = "Weave",    d = "Knit the current document and generate a beamer presentation" },
     RMakeAll            = { m = "", k = "", c = "Weave",    d = "Knit the current document and generate all formats in the header" },

--- a/lua/r/maps.lua
+++ b/lua/r/maps.lua
@@ -137,6 +137,9 @@ local control = function(file_type)
     create_maps("v",   "RViewDF",           "rv", "<Cmd>lua require('r.run').action('viewobj', 'v')")
     create_maps("v",   "RDputObj",          "td", "<Cmd>lua require('r.run').action('dputtab', 'v')")
 
+    create_maps("nvi", "RSplitPathPaste",    "sp", "<Cmd>lua require('r.path').split_path('paste')")
+    create_maps("nvi", "RSplitPathHere",    "sh", "<Cmd>lua require('r.path').split_path('here')")
+
     if type(config.csv_app) == "function" or config.csv_app == "" then
         create_maps("ni",  "RViewDFs",          "vs", "<Cmd>lua require('r.run').action('viewobj', 'n', ', howto=\"split\"')")
         create_maps("ni",  "RViewDFv",          "vv", "<Cmd>lua require('r.run').action('viewobj', 'n', ', howto=\"vsplit\"')")

--- a/lua/r/path.lua
+++ b/lua/r/path.lua
@@ -35,7 +35,7 @@ local function replace_path(node, formatted_path)
     )
 end
 
-M.split_path = function(prefix)
+M.separate = function(prefix)
     local node = vim.treesitter.get_node()
 
     if node and node:type() == "string" then

--- a/lua/r/path.lua
+++ b/lua/r/path.lua
@@ -1,0 +1,72 @@
+local M = {}
+
+local unquote_and_split_file_path = function(file_path)
+    local quote = file_path:match("^[\"']")
+    if quote then
+        file_path = file_path:sub(2, -2) -- Remove surrounding quotes
+    end
+
+    -- Split the path into components
+    local components = {}
+    for component in file_path:gmatch("[^/]+") do
+        table.insert(components, component)
+    end
+
+    -- If path starts with a /, add it to the first component
+    if file_path:sub(1, 1) == "/" then components[1] = "/" .. components[1] end
+
+    -- Join the components with the detected quote
+    local result = table.concat(components, quote .. ", " .. quote)
+
+    return result
+end
+
+local function replace_string(node, formatted_path)
+    local bufnr = vim.api.nvim_get_current_buf()
+    local start_row, start_col, end_row, end_col = node:range()
+
+    vim.api.nvim_buf_set_text(
+        bufnr,
+        start_row,
+        start_col,
+        end_row,
+        end_col,
+        { formatted_path }
+    )
+end
+
+M.split_path = function(prefix)
+    local node = vim.treesitter.get_node()
+
+    if node and node:type() == "string" then
+        local path = vim.treesitter.get_node_text(node, 0)
+
+        -- Check if the path is a URL or doesn't contain slashes
+        if path:match("^(https?|ftp)://") or not path:match("/") then return end
+
+        -- Traverse up the syntax tree until we find a call_expression node
+        local parent = node:parent()
+        while parent do
+            if parent:type() == "call" then
+                local function_name = vim.treesitter.get_node_text(parent, 0)
+                if function_name:match("paste") or function_name:match("here") then
+                    return
+                end
+            end
+            parent = parent:parent()
+        end
+
+        -- Format the path
+        local formatted_path = unquote_and_split_file_path(path)
+
+        if prefix == "paste" then
+            formatted_path = 'paste("' .. formatted_path .. '", sep = "/")'
+        elseif prefix == "here" then
+            formatted_path = 'here("' .. formatted_path .. '")'
+        end
+
+        replace_string(node, formatted_path)
+    end
+end
+
+return M

--- a/lua/r/path.lua
+++ b/lua/r/path.lua
@@ -42,7 +42,9 @@ M.split_path = function(prefix)
         local path = vim.treesitter.get_node_text(node, 0)
 
         -- Check if the path is a URL or doesn't contain slashes
-        if path:match("^(https?|ftp)://") or not path:match("/") then return end
+        if path:match("https?://") or path:match("ftp://") or not path:match("/") then
+            return
+        end
 
         -- Traverse up the syntax tree until we find a call_expression node
         local parent = node:parent()

--- a/lua/r/path.lua
+++ b/lua/r/path.lua
@@ -21,7 +21,7 @@ local unquote_and_split_file_path = function(file_path)
     return result
 end
 
-local function replace_string(node, formatted_path)
+local function replace_path(node, formatted_path)
     local bufnr = vim.api.nvim_get_current_buf()
     local start_row, start_col, end_row, end_col = node:range()
 
@@ -42,7 +42,12 @@ M.split_path = function(prefix)
         local path = vim.treesitter.get_node_text(node, 0)
 
         -- Check if the path is a URL or doesn't contain slashes
-        if path:match("https?://") or path:match("ftp://") or not path:match("/") then
+        if
+            path:match("https?://")
+            or path:match("ftp://")
+            or path:match("s3://")
+            or not path:match("/")
+        then
             return
         end
 
@@ -67,7 +72,7 @@ M.split_path = function(prefix)
             formatted_path = 'here("' .. formatted_path .. '")'
         end
 
-        replace_string(node, formatted_path)
+        replace_path(node, formatted_path)
     end
 end
 


### PR DESCRIPTION
This PR adds two new keybindings:

1. `<localleader>sp`: Split a file path and wrap it around the `paste()` function.
2.  `<localleader>sh`: Split a file path and wrap it around the `here()` function.

This allows to breaks long lines to nicely format code.

![Peek 2024-04-05 08-47](https://github.com/R-nvim/R.nvim/assets/4519221/bc58dd0f-4f06-4b35-afd5-f620e56a4ed5)

After, one can use the preferred formatter to wrap lines.