### PR TITLE
add nvimpager=vertical option, split help doc vertically. See #117

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ arguments that will be passed to `base::source()` and include the argument
 directly to the R Console without saving the code in a temporary file to be
 sourced (`max_lines_to_paste`).
 
-We reduced the number of options on how to display R documentation to: `"split"`,
-`"tab"`, `"float"` (not implemented yet), and `"no"`.
+The options for displaying R documentation (`nvimpager`) are now: `"split_h"`,
+`"split_v"`, `"tab"`, `"float"` (not implemented yet), and `"no"`.
 
 The options `openpdf` and `openhtml` were renamed as `open_pdf` and
 `open_html`, they now are strings and there with a minor change in how they
@@ -232,6 +232,6 @@ but temporary files are used in a few cases.
 - [colorout](https://github.com/jalvesaq/colorout): a package to colorize R's output.
 
 [cmp-r]: https://github.com/R-nvim/cmp-r
-[Neovim]: https://github.com/neovim/neovim
+[neovim]: https://github.com/neovim/neovim
 [southernlights]: https://github.com/jalvesaq/southernlights
 [colorout]: https://github.com/jalvesaq/colorout

--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -1043,6 +1043,7 @@ The valid values of `nvimpager` are:
    "split"     : Split the window horizontally, as `:help` does. That is,
                  display R documentation above the editor window or at the
                  very top of the screen.
+   "vertical"  : Split the window vertically.
    "float"     : Not implemented yet.
    "no"        : Do not show R documentation in Neovim.
 

--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -1040,10 +1040,11 @@ The valid values of `nvimpager` are:
    "tab"       : Show the help document in a new tab. If there is already a
                  tab with an R help document tab, use it.
                  This is the default if `external_term` = `true`.
-   "split"     : Split the window horizontally, as `:help` does. That is,
+   "split_h"   : Split the window horizontally, as `:help` does. That is,
                  display R documentation above the editor window or at the
                  very top of the screen.
-   "vertical"  : Split the window vertically.
+   "split_v"   : Split the window vertically. Display R documentation to
+                 the right of the editor window.
    "float"     : Not implemented yet.
    "no"        : Do not show R documentation in Neovim.
 

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -48,7 +48,7 @@ local config = {
     min_editor_width    = 80,
     non_r_compl         = true,
     setwd               = "no",
-    nvimpager           = "split",
+    nvimpager           = "split_h",
     objbr_allnames      = false,
     objbr_auto_start    = false,
     objbr_h             = 10,
@@ -207,7 +207,7 @@ local validate_user_opts = function()
 
     validate_string("auto_start", { "no", "on startup", "always" })
     validate_string("editing_mode", { "vi", "emacs" })
-    validate_string("nvimpager", { "no", "tab", "split", "float", "vertical" })
+    validate_string("nvimpager", { "no", "tab", "split_h", "split_v", "float" })
     validate_string("open_html", { "no", "open", "open and focus" })
     validate_string("open_pdf", { "no", "open", "open and focus" })
     validate_string("setwd", { "no", "file", "nvim" })
@@ -417,7 +417,7 @@ local do_common_global = function()
     end
 
     if type(config.external_term) == "boolean" and config.external_term == false then
-        config.nvimpager = "split"
+        config.nvimpager = "split_h"
         config.save_win_pos = false
         config.arrange_windows = false
     else

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -207,7 +207,7 @@ local validate_user_opts = function()
 
     validate_string("auto_start", { "no", "on startup", "always" })
     validate_string("editing_mode", { "vi", "emacs" })
-    validate_string("nvimpager", { "no", "tab", "split", "float" })
+    validate_string("nvimpager", { "no", "tab", "split", "float", "vertical" })
     validate_string("open_html", { "no", "open", "open and focus" })
     validate_string("open_pdf", { "no", "open", "open and focus" })
     validate_string("setwd", { "no", "file", "nvim" })

--- a/lua/r/doc.lua
+++ b/lua/r/doc.lua
@@ -109,7 +109,7 @@ M.show = function(rkeyword, txt)
     else
         if vpager == "tab" or vpager == "float" then
             vim.cmd("tabnew R_doc")
-        elseif vpager == "vertical" then
+        elseif vpager == "split_v" then
             vim.cmd("vsplit R_doc")
         else
             if vim.fn.winwidth(0) < 80 then

--- a/lua/r/doc.lua
+++ b/lua/r/doc.lua
@@ -76,13 +76,14 @@ M.show = function(rkeyword, txt)
     if
         not config.nvimpager:find("tab")
         and not config.nvimpager:find("split")
+        and not config.nvimpager:find("vertical")
         and not config.nvimpager:find("float")
         and not config.nvimpager:find("no")
     then
         warn(
             'Invalid `nvimpager` value: "'
                 .. config.nvimpager
-                .. '". Valid values are: "tab", "split", "float", and "no".'
+                .. '". Valid values are: "tab", "split", "vertical", "float", and "no".'
         )
         return
     end
@@ -124,12 +125,16 @@ M.show = function(rkeyword, txt)
         if vpager == "tab" or vpager == "float" then
             vim.cmd("tabnew R_doc")
         else
-            if vim.fn.winwidth(0) < 80 then
-                vim.cmd("topleft split R_doc")
+            if vpager == "vertical" then
+                vim.cmd("vsplit R_doc")
             else
-                vim.cmd("split R_doc")
+                if vim.fn.winwidth(0) < 80 then
+                    vim.cmd("topleft split R_doc")
+                else
+                    vim.cmd("split R_doc")
+                end
+                if vim.fn.winheight(0) < 20 then vim.cmd("resize 20") end
             end
-            if vim.fn.winheight(0) < 20 then vim.cmd("resize 20") end
         end
     end
 

--- a/lua/r/doc.lua
+++ b/lua/r/doc.lua
@@ -73,27 +73,12 @@ end
 ---@param rkeyword string The topic
 ---@param txt string The text to display
 M.show = function(rkeyword, txt)
-    if
-        not config.nvimpager:find("tab")
-        and not config.nvimpager:find("split")
-        and not config.nvimpager:find("vertical")
-        and not config.nvimpager:find("float")
-        and not config.nvimpager:find("no")
-    then
-        warn(
-            'Invalid `nvimpager` value: "'
-                .. config.nvimpager
-                .. '". Valid values are: "tab", "split", "vertical", "float", and "no".'
-        )
-        return
-    end
-
     -- Check if `nvimpager` is "no" because the user might have set the pager
     -- in the .Rprofile.
     local vpager
     if config.nvimpager == "no" then
         if type(config.external_term) == "boolean" and not config.external_term then
-            vpager = "split"
+            vpager = "split_h"
         else
             vpager = "tab"
         end
@@ -124,17 +109,15 @@ M.show = function(rkeyword, txt)
     else
         if vpager == "tab" or vpager == "float" then
             vim.cmd("tabnew R_doc")
+        elseif vpager == "vertical" then
+            vim.cmd("vsplit R_doc")
         else
-            if vpager == "vertical" then
-                vim.cmd("vsplit R_doc")
+            if vim.fn.winwidth(0) < 80 then
+                vim.cmd("topleft split R_doc")
             else
-                if vim.fn.winwidth(0) < 80 then
-                    vim.cmd("topleft split R_doc")
-                else
-                    vim.cmd("split R_doc")
-                end
-                if vim.fn.winheight(0) < 20 then vim.cmd("resize 20") end
+                vim.cmd("split R_doc")
             end
+            if vim.fn.winheight(0) < 20 then vim.cmd("resize 20") end
         end
     end
 

--- a/lua/r/edit.lua
+++ b/lua/r/edit.lua
@@ -255,14 +255,7 @@ M.open_example = function()
     if config.nvimpager == "tabnew" or config.nvimpager == "tab" then
         vim.cmd("tabnew " .. config.tmpdir:gsub(" ", "\\ ") .. "/example.R")
     else
-        local nvimpager = config.nvimpager
         if config.nvimpager == "split_v" then
-            local wwidth = vim.fn.winwidth(0)
-            local min_e = (config.editor_w > 78) and config.editor_w or 78
-            local min_h = (config.help_w > 78) and config.help_w or 78
-            if wwidth < (min_e + min_h) then nvimpager = "split_h" end
-        end
-        if nvimpager == "split_v" then
             vim.cmd(
                 "belowright vsplit " .. config.tmpdir:gsub(" ", "\\ ") .. "/example.R"
             )

--- a/lua/r/edit.lua
+++ b/lua/r/edit.lua
@@ -256,13 +256,13 @@ M.open_example = function()
         vim.cmd("tabnew " .. config.tmpdir:gsub(" ", "\\ ") .. "/example.R")
     else
         local nvimpager = config.nvimpager
-        if config.nvimpager == "vertical" then
+        if config.nvimpager == "split_v" then
             local wwidth = vim.fn.winwidth(0)
             local min_e = (config.editor_w > 78) and config.editor_w or 78
             local min_h = (config.help_w > 78) and config.help_w or 78
-            if wwidth < (min_e + min_h) then nvimpager = "horizontal" end
+            if wwidth < (min_e + min_h) then nvimpager = "split_h" end
         end
-        if nvimpager == "vertical" then
+        if nvimpager == "split_v" then
             vim.cmd(
                 "belowright vsplit " .. config.tmpdir:gsub(" ", "\\ ") .. "/example.R"
             )


### PR DESCRIPTION
Adds "vertical" option to `nvimpager`, which causes help documentation to open in a vertical split instead of the default horizontal split.

Very lightly tested...