### PR TITLE
add option `start_libs`

### DIFF
--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -432,7 +432,7 @@ If `cmp-r` (a source for `nvim-cmp`) is installed, Neovim can
 automatically complete the names of R objects as you type them.
 
 R.nvim does not complete the names of all functions of all installed packages
-(see |R_start_libs|); only of loaded libraries.
+(see |start_libs|); only of loaded libraries.
 
 For both `library()` and `require()`, when completing the first argument, the
 popup list shows the names of installed packages.
@@ -660,7 +660,7 @@ command:
 |R_path|              Directory where R is
 |R_app|, |R_cmd|        Names of R applications
 |R_args|              Arguments to pass to R
-|R_start_libs|        Objects for auto completion and syntax highlight
+|start_libs|          Objects for auto completion and syntax highlight
 |Rout_more_colors|    More syntax highlighting in R output
 |routnotab|           Show output of R CMD BATCH in new window
 |config_tmux|         Don't use a specially built Tmux config file

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -82,6 +82,7 @@ local config = {
     skim_app_path       = "",
     source_args         = "",
     specialplot         = false,
+    start_libs          = "base,stats,graphics,grDevices,utils,methods",
     synctex             = true,
     term_pid            = 0,
     term_title          = "term",


### PR DESCRIPTION
When the option `start_libs` is set, it works as expected, but a warning pops up, "Unrecognized option \`start_libs\`."