### PR TITLE
Fixes for `.Rproj` files

### DIFF
--- a/lua/r/edit.lua
+++ b/lua/r/edit.lua
@@ -33,7 +33,7 @@ M.pipe = function()
     }
 
     local var_exists, buf_pipe_version = pcall(
-        function() vim.api.nvim_buf_get_var(0, "rnvim_pipe_version") end
+        function() return vim.api.nvim_buf_get_var(0, "rnvim_pipe_version") end
     )
     if not var_exists then buf_pipe_version = nil end
 

--- a/lua/r/rproj.lua
+++ b/lua/r/rproj.lua
@@ -84,6 +84,9 @@ function M.parse(file)
                 fields[name] = true
             elseif val == "No" or val == "no" then
                 fields[name] = false
+            elseif val == "Default" or val == "default" then
+                -- In this case, the normal R.nvim config will be used
+                fields[name] = nil
             else
                 warn(
                     "WARNING: Unexpected configuration in "


### PR DESCRIPTION
* Allows `'Default'` for some `.Rproj` fields
* Adds a missing `return`, which was causing the `UseNativePipeVersion` to have no effect