### PR TITLE
Add vim.ui.open support for pdf opening

### DIFF
--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -1482,14 +1482,12 @@ Wayland windows managers other than Sway.
 
 R.nvim will call Sumatra to open the PDF on Windows, Skim on Mac OS X, and
 Zathura on Linux, but you can change the values of `synctex` and `pdfviewer`
-in your config if you don't need SyncTeX support. For systems using 
-Neovim v10.0+, setting `pdfviewer` to an empty string will open the PDF with 
-the OS default application. Example:
+in your config if you don't need SyncTeX support. Setting `pdfviewer` to an
+empty string will open the PDF with the OS default application. Examples:
 >lua
    synctex = false
-   pdfviewer = "open"     -- Default PDF viewer (macOS or Windows)
-   pdfviewer = "xdg-open" -- Default PDF viewer (Linux)
-   pdfviewer = ""         -- Default PDF viewer (Any) [Requires Neovim v0.10+]
+   pdfviewer = "evince"   -- Use Evince as PDF viewer
+   pdfviewer = ""         -- Default PDF viewer (and no SyncTeX support)
 <
 If editing an Rmd file, you can produce the html result with <LocalLeader>kr
 or <LocalLeader>kh (it may also work with other file types). The html file

--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -1482,7 +1482,9 @@ Wayland windows managers other than Sway.
 
 R.nvim will call Sumatra to open the PDF on Windows, Skim on Mac OS X, and
 Zathura on Linux, but you can change the values of `synctex` and `pdfviewer`
-in your config if you don't need SyncTeX support. Example:
+in your config if you don't need SyncTeX support. For systems using 
+Neovim v10.0+, setting `pdfviewer` to an empty string will open the PDF with 
+the OS default application. Example:
 >lua
    synctex = false
    pdfviewer = "open"     -- Default PDF viewer (macOS or Windows)

--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -1485,8 +1485,9 @@ Zathura on Linux, but you can change the values of `synctex` and `pdfviewer`
 in your config if you don't need SyncTeX support. Example:
 >lua
    synctex = false
-   pdfviewer = "open"     -- Default PDF viewer on macOS or Windows
-   pdfviewer = "xdg-open" -- Default PDF viewer on Linux
+   pdfviewer = "open"     -- Default PDF viewer (macOS or Windows)
+   pdfviewer = "xdg-open" -- Default PDF viewer (Linux)
+   pdfviewer = ""         -- Default PDF viewer (Any) [Requires Neovim v0.10+]
 <
 If editing an Rmd file, you can produce the html result with <LocalLeader>kr
 or <LocalLeader>kh (it may also work with other file types). The html file

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -61,7 +61,7 @@ local config = {
     open_pdf            = "open and focus",
     paragraph_begin     = true,
     parenblock          = true,
-    pdfviewer           = "undefined",
+    pdfviewer           = "",
     quarto_preview_args = "",
     quarto_render_args  = "",
     rconsole_height     = 15,
@@ -806,6 +806,7 @@ local global_setup = function()
         table.insert(config_keys, tostring(k))
     end
 
+    set_pdf_viewer()
     apply_user_opts()
 
     -- Config values that depend on either system features or other config
@@ -829,7 +830,6 @@ local global_setup = function()
     else
         unix_config()
     end
-    set_pdf_viewer()
 
     -- Override default config values with user options for the second time.
     for k, v in pairs(user_opts) do

--- a/lua/r/pdf/generic.lua
+++ b/lua/r/pdf/generic.lua
@@ -5,6 +5,11 @@ local job = require("r.job")
 local M = {}
 
 M.open = function(fullpath)
+    if config.pdfviewer == "" then
+        vim.ui.open(fullpath)
+        return
+    end
+
     local opts = {
         on_exit = require("r.job").on_exit,
         detach = true,

--- a/lua/r/pdf/init.lua
+++ b/lua/r/pdf/init.lua
@@ -27,9 +27,7 @@ M.setup = function()
         end
     end
 
-    if config.pdfviewer ~= "" then
-        check_installed()
-    end
+    if config.pdfviewer ~= "" then check_installed() end
 
     if config.pdfviewer == "zathura" then
         M.open2 = require("r.pdf.zathura").open

--- a/lua/r/pdf/init.lua
+++ b/lua/r/pdf/init.lua
@@ -5,6 +5,12 @@ local job = require("r.job")
 local uv = vim.loop
 
 local check_installed = function()
+    if ((vim.fn.has("nvim-0.10") == 0) and (config.pdfviewer == "")) then
+        warn(
+            "R.nvim: Having a `pdfviewer` value of `\"\"` is only supported for Neovim 0.10+."
+        )
+    end
+
     if (vim.fn.executable(config.pdfviewer) == 0) and (config.pdfviewer ~= "") then
         warn(
             "R.nvim: Please, set the value of `pdfviewer`. The application `"

--- a/lua/r/pdf/init.lua
+++ b/lua/r/pdf/init.lua
@@ -5,7 +5,7 @@ local job = require("r.job")
 local uv = vim.loop
 
 local check_installed = function()
-    if vim.fn.executable(config.pdfviewer) == 0 then
+    if (vim.fn.executable(config.pdfviewer) == 0) and (config.pdfviewer ~= "") then
         warn(
             "R.nvim: Please, set the value of `pdfviewer`. The application `"
                 .. config.pdfviewer
@@ -61,6 +61,9 @@ end
 ---@param fullpath string The path to the PDF file.
 M.open = function(fullpath)
     if config.open_pdf == "no" then return end
+
+    -- If pdfviewer is blank, just call vim.ui.open (opens with the os default for ANY file type)
+    if config.pdfviewer == "" then vim.ui.open(fullpath) return end
 
     if fullpath == "Get Master" then
         local fpath = require("r.rnw").SyncTeX_get_master() .. ".pdf"

--- a/lua/r/rnw.lua
+++ b/lua/r/rnw.lua
@@ -441,6 +441,11 @@ M.SyncTeX_forward = function(gotobuf)
     local rnwf = vim.fn.expand("%:t")
     local basedir
 
+    if config.pdfviewer == "" then
+        warn("R.nvim has no support for SyncTeX when 'pdfviewer' is an empty string.")
+        return
+    end
+
     if vim.fn.filereadable(vim.fn.expand("%:p:r") .. "-concordance.tex") == 1 then
         lnum = vim.api.nvim_win_get_cursor(0)[1]
     else


### PR DESCRIPTION
In Neovim 0.10, a new function `vim.ui.open` was added which opens ANY file with the system's configured application for said file's filetype. 

As I'm not very familiar with the structure of this project, this PR just adds a line and suppresses an error. I implemented it quickly by letting the user specify `pdfviewer = ""` in their config. My hope is that someone with more familiarity to the layout and style of this repo could help me implement this in a way consistent with the repo.

(I understand that using `vim.ui.open` will most likely result in a loss of support for SyncTeX, but the point of this PR is to start discussing basic opening ability with the new command)