### PR TITLE
Improvements when building completion data

### DIFF
--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -669,6 +669,7 @@ command:
 |objbr_opendf|        Display data.frames open in the Object Browser
 |objbr_openlist|      Display lists open in the Object Browser
 |objbr_allnames|      Display hidden objects in the Object Browser
+|compl_data|          Limits of completion data (avoid R slowdown)
 |nvimpager|           Use Neovim to see R documentation
 |open_example|        Use Neovim to display R examples
 |R_path|              Directory where R is
@@ -995,13 +996,13 @@ cursor is not at the beginning of the line.
 
 
 ------------------------------------------------------------------------------
-6.7. Object Browser options                                   *objbr_w*
+6.7. Object Browser and completion options                    *objbr_w*
                                                               *objbr_h*
                                                               *objbr_place*
                                                               *objbr_opendf*
                                                               *objbr_openlist*
                                                               *objbr_allnames*
-
+                                                              *compl_data*
 By default, the Object Browser will be created at the right of the script
 window, and with 40 columns. Valid values for the Object Browser placement are
 the combination of either "script" or "console" and "right", "left", "above",
@@ -1041,6 +1042,40 @@ only if it is explicitly opened. The options `objbr_opendf` and
 `objbr_openlist` control the initial status (either opened or closed) of,
 respectively, `data.frames` and `lists`. The options are ignored for
 `data.frames` and `lists` of libraries which are always started closed.
+
+When building the list of objects for auto completion and for the Object
+Browser, `nvimcom` inspects lists only as deep as 12 levels. When the time to
+build the completion data is higher than 100 ms `nvimcom` decreases the number
+of levels it inspects in lists. Even if `nvimcom` can build the completion
+data in less than 100 ms, it also decrease the maximum level of list
+inspection if the resulting completion data is bigger than 1,000,000 bytes
+because big data may take a noticeably long time to be transmitted through the
+TCP connection. When `nvimcom` automatically decreases the depth of list
+inspection, if `nvimcom.verbose` is > 1, it outputs information like the
+following on R Console:
+
+   nvimcom:
+       Time to buiild list of objects: 7.582 ms (max_time = 100 ms)
+       List size: 1611734 bytes (max_size = 1000000 bytes)
+       New max_depth: 9
+
+You can set different values for `time_limit`, `size_limit`, and `max_depth`
+in the Lua table `compl_data` in your `R.nvim` config. Below are the default
+values:
+>lua
+    compl_data = {
+        max_depth = 12,
+        max_size = 1000000,
+        max_time = 100,
+    },
+<
+You should increase the value of `max_depth` if you want to complete or see in
+the Object Browser more than 12 levels from lists. You should increase either
+`max_size` or `max_time` if `nvimcom` needs more space or more time to build
+the completion data with the desired list depth. You should decrease the
+values if you notice any delay when R is running commands. In this case,
+please, put `options(nvimcom.verbose = 1)` in your `~/.Rprofile` and use the
+information output by `nvimcom` to decide what parameter to change.
 
 
 ------------------------------------------------------------------------------

--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -1044,7 +1044,7 @@ respectively, `data.frames` and `lists`. The options are ignored for
 `data.frames` and `lists` of libraries which are always started closed.
 
 When building the list of objects for auto completion and for the Object
-Browser, `nvimcom` inspects lists only as deep as 12 levels. When the time to
+Browser, `nvimcom` inspects lists only as deep as 3 levels. When the time to
 build the completion data is higher than 100 ms `nvimcom` decreases the number
 of levels it inspects in lists. Even if `nvimcom` can build the completion
 data in less than 100 ms, it also decrease the maximum level of list
@@ -1059,18 +1059,22 @@ following on R Console:
        List size: 1611734 bytes (max_size = 1000000 bytes)
        New max_depth: 9
 
+The value of `max_depth` will automatically increase if necessary when you try
+to open a list in the Object Browser. However, it will not increase if you try
+to complete deep elements in the list.
+
 You can set different values for `time_limit`, `size_limit`, and `max_depth`
 in the Lua table `compl_data` in your `R.nvim` config. Below are the default
 values:
 >lua
     compl_data = {
-        max_depth = 12,
+        max_depth = 3,
         max_size = 1000000,
         max_time = 100,
     },
 <
 You should increase the value of `max_depth` if you want to complete or see in
-the Object Browser more than 12 levels from lists. You should increase either
+the Object Browser more than 3 list levels. You should increase either
 `max_size` or `max_time` if `nvimcom` needs more space or more time to build
 the completion data with the desired list depth. You should decrease the
 values if you notice any delay when R is running commands. In this case,

--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -669,7 +669,7 @@ command:
 |objbr_opendf|        Display data.frames open in the Object Browser
 |objbr_openlist|      Display lists open in the Object Browser
 |objbr_allnames|      Display hidden objects in the Object Browser
-|compl_data|          Limits of completion data (avoid R slowdown)
+|compl_data|          Limits to completion data (avoid R slowdown)
 |nvimpager|           Use Neovim to see R documentation
 |open_example|        Use Neovim to display R examples
 |R_path|              Directory where R is

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -26,7 +26,7 @@ local config = {
     close_term          = true,
     compldir            = "",
     compl_data          = {
-        max_depth = 12,
+        max_depth = 3,
         max_size = 1000000,
         max_time = 100,
     },

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -25,6 +25,11 @@ local config = {
     clear_line          = false,
     close_term          = true,
     compldir            = "",
+    compl_data          = {
+        max_depth = 12,
+        max_size = 1000000,
+        max_time = 100,
+    },
     config_tmux         = true,
     csv_app             = "",
     disable_cmds        = { "" },

--- a/lua/r/run.lua
+++ b/lua/r/run.lua
@@ -54,9 +54,7 @@ start_R2 = function()
 
     table.insert(
         start_options,
-        "options(nvimcom.max_depth = "
-            .. tostring(config.compl_data.max_depth)
-            .. ")"
+        "options(nvimcom.max_depth = " .. tostring(config.compl_data.max_depth) .. ")"
     )
     table.insert(
         start_options,

--- a/lua/r/run.lua
+++ b/lua/r/run.lua
@@ -52,6 +52,20 @@ start_R2 = function()
         'Sys.setenv("R_DEFAULT_PACKAGES" = "' .. rdp .. '")',
     }
 
+    table.insert(
+        start_options,
+        "options(nvimcom.max_depth = "
+            .. tostring(config.compl_data.max_depth)
+            .. ")"
+    )
+    table.insert(
+        start_options,
+        "options(nvimcom.max_size = " .. tostring(config.compl_data.max_size) .. ")"
+    )
+    table.insert(
+        start_options,
+        "options(nvimcom.max_time = " .. tostring(config.compl_data.max_time) .. ")"
+    )
     if config.objbr_allnames then
         table.insert(start_options, "options(nvimcom.allnames = TRUE)")
     else

--- a/lua/r/server.lua
+++ b/lua/r/server.lua
@@ -166,6 +166,7 @@ local start_rnvimserver = function()
     if config.objbr_allnames then rns_env["RNVIM_OBJBR_ALLNAMES"] = "TRUE" end
     rns_env["RNVIM_RPATH"] = config.R_cmd
     rns_env["RNVIM_LOCAL_TMPDIR"] = config.localtmpdir
+    rns_env["RNVIM_MAX_DEPTH"] = tostring(config.compl_data.max_depth)
 
     -- We have to set R's home directory on Windows because rnvimserver will
     -- run R to build the list for auto completion.

--- a/nvimcom/DESCRIPTION
+++ b/nvimcom/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nvimcom
-Version: 0.9.41
-Date: 2024-04-05
+Version: 0.9.42
+Date: 2024-06-14
 Title: Intermediate the Communication Between R and Neovim
 Author: Jakson Aquino
 Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>

--- a/nvimcom/R/nvimcom.R
+++ b/nvimcom/R/nvimcom.R
@@ -25,6 +25,9 @@ NvimcomEnv$pkgRdDB <- list()
         options(nvimcom.setwidth = TRUE)
         options(nvimcom.autoglbenv = 0)
         options(nvimcom.nvimpager = TRUE)
+        options(nvimcom.max_depth = 12)
+        options(nvimcom.max_size = 1000000)
+        options(nvimcom.max_time = 100)
         options(nvimcom.delim = "\t")
     }
     if (getOption("nvimcom.nvimpager"))
@@ -51,6 +54,9 @@ NvimcomEnv$pkgRdDB <- list()
            as.integer(getOption("nvimcom.allnames")),
            as.integer(getOption("nvimcom.setwidth")),
            as.integer(getOption("nvimcom.autoglbenv")),
+           as.integer(getOption("nvimcom.max_depth")),
+           as.integer(getOption("nvimcom.max_size")),
+           as.integer(getOption("nvimcom.max_time")),
            NvimcomEnv$info[1],
            NvimcomEnv$info[2],
            PACKAGE = "nvimcom")

--- a/nvimcom/src/apps/data_structures.c
+++ b/nvimcom/src/apps/data_structures.c
@@ -18,9 +18,7 @@ static size_t glbnv_buffer_sz; // Global environment buffer size
 static ListStatus *listTree;   // Root node of the list status tree
 static int max_depth = 2;      // Max list depth in nvimcom
 
-void set_max_depth(int m) {
-    max_depth = m;
-}
+void set_max_depth(int m) { max_depth = m; }
 
 static void change_all_stt(ListStatus *root, int stt) {
     if (root != NULL) {
@@ -587,7 +585,7 @@ void toggle_list_status(char *s) {
         // Check if max_depth in nvimcom is enough
         char *t = s;
         int n = 0;
-        while(*t) {
+        while (*t) {
             if (*t == '$' || *t == '@')
                 n++;
             t++;

--- a/nvimcom/src/apps/data_structures.c
+++ b/nvimcom/src/apps/data_structures.c
@@ -582,7 +582,7 @@ void toggle_list_status(char *s) {
     ListStatus *p = search(listTree, s);
     if (p) {
 
-        // Check if max_depth in nvimcom is enough
+        // Count list levels
         char *t = s;
         int n = 0;
         while (*t) {
@@ -590,6 +590,7 @@ void toggle_list_status(char *s) {
                 n++;
             t++;
         }
+        // Check if the value of max_depth is high enough
         if (p->status == 0 && n >= max_depth) {
             max_depth++;
             char b[16];

--- a/nvimcom/src/apps/data_structures.h
+++ b/nvimcom/src/apps/data_structures.h
@@ -41,8 +41,9 @@ typedef struct pkg_data_ {
     struct pkg_data_ *next; // Pointer to next package data
 } PkgData;
 
+void set_max_depth(int m);
 int get_list_status(const char *s, int stt);
-void toggle_list_status(const char *s);
+void toggle_list_status(char *s);
 void update_inst_libs(void);
 void update_pkg_list(char *libnms);  // Update package list
 void update_glblenv_buffer(char *g); // Update global environment buffer

--- a/nvimcom/src/apps/obbr.c
+++ b/nvimcom/src/apps/obbr.c
@@ -173,9 +173,8 @@ static const char *write_ob_line(const char *p, const char *bs, char *prfx,
             return p;
         }
 
-        if (str_here(p, base1) == 0 && str_here(p, base2) == 0) {
+        if (str_here(p, base1) == 0 && str_here(p, base2) == 0)
             return p;
-        }
 
         int len = strlen(prfx);
         if (nvimcom_is_utf8) {

--- a/nvimcom/src/apps/obbr.c
+++ b/nvimcom/src/apps/obbr.c
@@ -173,8 +173,9 @@ static const char *write_ob_line(const char *p, const char *bs, char *prfx,
             return p;
         }
 
-        if (str_here(p, base1) == 0 && str_here(p, base2) == 0)
+        if (str_here(p, base1) == 0 && str_here(p, base2) == 0) {
             return p;
+        }
 
         int len = strlen(prfx);
         if (nvimcom_is_utf8) {

--- a/nvimcom/src/apps/rnvimserver.c
+++ b/nvimcom/src/apps/rnvimserver.c
@@ -75,6 +75,7 @@ static void init_global_vars(void) {
     } else {
         strncpy(localtmpdir, getenv("RNVIM_TMPDIR"), 255);
     }
+    set_max_depth(atoi(getenv("RNVIM_MAX_DEPTH")));
 
     compl_buffer = calloc(compl_buffer_size, sizeof(char));
 }

--- a/nvimcom/src/apps/tcp.c
+++ b/nvimcom/src/apps/tcp.c
@@ -96,6 +96,10 @@ static void ParseMsg(char *b) {
             else
                 complete(id, base, fnm, dtfrm, NULL);
             break;
+        case 'D': // set max_depth of lists in the completion data
+            b++;
+            set_max_depth(atoi(b));
+            break;
         case 'F': // strtok doesn't work here because "base" might be empty.
             b++;
             char *args;

--- a/nvimcom/src/nvimcom.c
+++ b/nvimcom/src/nvimcom.c
@@ -605,19 +605,22 @@ static char *nvimcom_glbnv_line(SEXP *x, const char *xname, const char *curenv,
             if (len == 0) { /* Empty list? */
                 int len1 = length(*x);
                 if (len1 > 0) { /* List without names */
-                    len1 -= 1;
-                    if (newenv[strlen(newenv) - 1] == '$')
-                        newenv[strlen(newenv) - 1] = 0; // Delete trailing '$'
-                    for (int i = 0; i < len1; i++) {
-                        snprintf(ebuf, 63, "[[%d]]", i + 1);
-                        elmt = VECTOR_ELT(*x, i);
-                        p = nvimcom_glbnv_line(&elmt, ebuf, newenv, p,
-                                               depth + 1);
-                    }
-                    snprintf(ebuf, 63, "[[%d]]", len1 + 1);
-                    PROTECT(elmt = VECTOR_ELT(*x, len));
-                    p = nvimcom_glbnv_line(&elmt, ebuf, newenv, p, depth + 1);
-                    UNPROTECT(1);
+                    // len1 -= 1;
+                    // if (newenv[strlen(newenv) - 1] == '$')
+                    //     newenv[strlen(newenv) - 1] = 0; // Delete trailing '$'
+                    // double tm1 = clock();
+                    // for (int i = 0; i < len1; i++) {
+                    //     snprintf(ebuf, 63, "[[%d]]", i + 1);
+                    //     elmt = VECTOR_ELT(*x, i);
+                    //     p = nvimcom_glbnv_line(&elmt, ebuf, newenv, p,
+                    //                            depth + 1);
+                    // }
+                    // double tmdiff2 = 1000 * ((double)clock() - tm1) / CLOCKS_PER_SEC;
+                    // REprintf("LOOP TIME: %g (%s)\n", tmdiff2, newenv);
+                    // snprintf(ebuf, 63, "[[%d]]", len1 + 1);
+                    // PROTECT(elmt = VECTOR_ELT(*x, len));
+                    // p = nvimcom_glbnv_line(&elmt, ebuf, newenv, p, depth + 1);
+                    // UNPROTECT(1);
                 }
             } else { /* Named list */
                 SEXP eexp;

--- a/nvimcom/src/nvimcom.c
+++ b/nvimcom/src/nvimcom.c
@@ -64,9 +64,10 @@ static size_t tcp_header_len; // Length of nvimsecr + 9. Stored in a
                               // variable to avoid repeatedly calling
                               // strlen().
 
-static double timelimit = 100.0; // Maximum acceptable time to build list of .GlobalEnv objects
-static int sizelimit = 1000000; // Maximum acceptable size of string representing
-                                // .GlobalEnv (list of objects)
+static double timelimit =
+    100.0; // Maximum acceptable time to build list of .GlobalEnv objects
+static int sizelimit = 1000000; // Maximum acceptable size of string
+                                // representing .GlobalEnv (list of objects)
 static int maxdepth = 12; // How many levels to parse in lists and S4 objects
 // when building list of objects for auto-completion. The value decreases if
 // the listing is too slow.
@@ -597,7 +598,8 @@ static char *nvimcom_glbnv_line(SEXP *x, const char *xname, const char *curenv,
                     for (int i = 0; i < len1; i++) {
                         snprintf(ebuf, 63, "[[%d]]", i + 1);
                         elmt = VECTOR_ELT(*x, i);
-                        p = nvimcom_glbnv_line(&elmt, ebuf, newenv, p, depth + 1);
+                        p = nvimcom_glbnv_line(&elmt, ebuf, newenv, p,
+                                               depth + 1);
                     }
                     snprintf(ebuf, 63, "[[%d]]", len1 + 1);
                     PROTECT(elmt = VECTOR_ELT(*x, len1));
@@ -721,11 +723,12 @@ static void nvimcom_globalenv_list(void) {
         snprintf(b, 15, "+D%d", maxdepth);
         send_to_nvim(b);
         if (verbose)
-            REprintf("nvimcom:\n"
-                    "    Time to buiild list of objects: %g ms (max_time = %g ms)\n"
-                    "    List size: %zu bytes (max_size = %d bytes)\n"
-                    "    New max_depth: %d\n",
-                    tmdiff, timelimit, strlen(glbnvbuf1), sizelimit, maxdepth);
+            REprintf(
+                "nvimcom:\n"
+                "    Time to buiild list of objects: %g ms (max_time = %g ms)\n"
+                "    List size: %zu bytes (max_size = %d bytes)\n"
+                "    New max_depth: %d\n",
+                tmdiff, timelimit, strlen(glbnvbuf1), sizelimit, maxdepth);
     }
 }
 
@@ -1173,8 +1176,8 @@ static void *client_loop_thread(__attribute__((unused)) void *arg)
  *
  * @param rinfo Information on R to be passed to nvim.
  */
-void nvimcom_Start(int *vrb, int *anm, int *swd, int *age,
-        int *imd, int *szl, int *tml, char **nvv, char **rinfo) {
+void nvimcom_Start(int *vrb, int *anm, int *swd, int *age, int *imd, int *szl,
+                   int *tml, char **nvv, char **rinfo) {
     verbose = *vrb;
     allnames = *anm;
     setwidth = *swd;

--- a/nvimcom/src/nvimcom.c
+++ b/nvimcom/src/nvimcom.c
@@ -717,6 +717,9 @@ static void nvimcom_globalenv_list(void) {
     double tmdiff = 1000 * ((double)clock() - tm) / CLOCKS_PER_SEC;
     if (tmdiff > timelimit || strlen(glbnvbuf1) > sizelimit) {
         maxdepth = curdepth - 1;
+        char b[16];
+        snprintf(b, 15, "+D%d", maxdepth);
+        send_to_nvim(b);
         if (verbose)
             REprintf("nvimcom:\n"
                     "    Time to buiild list of objects: %g ms (max_time = %g ms)\n"
@@ -1084,6 +1087,15 @@ static void nvimcom_parse_received_msg(char *buf) {
         } else {
             REprintf("\nvimcom: received invalid RNVIM_ID.\n");
         }
+        break;
+    case 'D':
+        p = buf;
+        p++;
+        maxdepth = atoi(p);
+        if (verbose > 3)
+            REprintf("New max_depth: %d\n", maxdepth);
+        flag_glbenv = 1;
+        nvimcom_fire();
         break;
     default: // do nothing
         REprintf("\nError [nvimcom]: Invalid message received: %s\n", buf);

--- a/nvimcom/src/nvimcom.c
+++ b/nvimcom/src/nvimcom.c
@@ -69,8 +69,7 @@ static int sizelimit = 1000000; // Maximum acceptable size of string representin
                                 // .GlobalEnv (list of objects)
 static int maxdepth = 12; // How many levels to parse in lists and S4 objects
 // when building list of objects for auto-completion. The value decreases if
-// the listing is too slow and increases if there are more levels to be parsed
-// and the listing is fast enough.
+// the listing is too slow.
 static int curdepth = 0; // Current level of the list or S4 object being parsed
                          // for auto-completion.
 static int autoglbenv = 0; // Should the list of objects in .GlobalEnv be
@@ -601,7 +600,7 @@ static char *nvimcom_glbnv_line(SEXP *x, const char *xname, const char *curenv,
                         p = nvimcom_glbnv_line(&elmt, ebuf, newenv, p, depth + 1);
                     }
                     snprintf(ebuf, 63, "[[%d]]", len1 + 1);
-                    PROTECT(elmt = VECTOR_ELT(*x, len));
+                    PROTECT(elmt = VECTOR_ELT(*x, len1));
                     p = nvimcom_glbnv_line(&elmt, ebuf, newenv, p, depth + 1);
                     UNPROTECT(1);
                 }


### PR DESCRIPTION
- New options to control how many list levels to include in completion data: `compl_data`.
- Decrease the default number of levels to include in the completion data (Close #142).
- Correctly get the last unnamed list element (Close #128).