### PR TITLE
✨ (R.nvim): add feature to convert numbers to explicit integers

### DIFF
--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -1782,7 +1782,18 @@ override the default `R.nvim` options. Currently, it has only one valid
 option:
 >lua
   rproj_prioritise = { "pipe_version" }
-<
+
+------------------------------------------------------------------------------
+6.36. Converting numbers to explicit integers              convert_range_int
+
+It is good practice to use the `L` suffix when referring to integers in R
+(e.g. `1L`). If you want to convert all numbers to explicit integers in the
+current buffer, you can use `<LocalLeader>cn` (change number). By default,
+this will not change numbers in a range (e.g. `1:10`). To allow changing
+numbers in a range (`1:10` -> `1L:10L`), put the following in your
+configuration:
+>lua
+  convert_range_int = true
 
 ==============================================================================
 7. Custom key bindings                                   *R.nvim-key-bindings*

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -24,6 +24,7 @@ local config = {
     clear_console       = true,
     clear_line          = false,
     close_term          = true,
+    convert_range_int   = false,
     compldir            = "",
     compl_data          = {
         max_depth = 3,

--- a/lua/r/format.lua
+++ b/lua/r/format.lua
@@ -27,7 +27,7 @@ local function is_adjacent_char_colon(bufnr, start_row, start_col, end_row, end_
     return prev_char == ":" or next_char == ":"
 end
 
-M.numformat = function(bufnr)
+M.formatnum = function(bufnr)
     bufnr = bufnr or vim.api.nvim_get_current_buf()
     local lang = parsers.get_buf_lang(bufnr)
 

--- a/lua/r/maps.lua
+++ b/lua/r/maps.lua
@@ -18,7 +18,7 @@ local map_desc = {
     RViewDFa            = { m = "", k = "", c = "Edit",     d = "View the head of a data.frame or matrix under cursor in a split window" },
     RShowEx             = { m = "", k = "", c = "Edit",     d = "Extract the Examples section and paste it in a split window" },
     RSeparatePathPaste  = { m = "", k = "", c = "Edit",     d = "Split the path of the file under the cursor and paste it using the paste() prefix function" },
-    RNumFormat          = { m = "", k = "", c = "Edit",     d = "Add an 'L' suffix after numbers to explicitly indicate them as integers." },
+    RFormatNum          = { m = "", k = "", c = "Edit",     d = "Add an 'L' suffix after numbers to explicitly indicate them as integers." },
     RSeparatePathHere   = { m = "", k = "", c = "Edit",     d = "Split the path of the file under the cursor and open it using the here() prefix function" },
     RNextRChunk         = { m = "", k = "", c = "Navigate", d = "Go to the next chunk of R code" },
     RGoToTeX            = { m = "", k = "", c = "Navigate", d = "Go the corresponding line in the generated LaTeX document" },
@@ -215,7 +215,8 @@ local edit = function()
     create_maps("nvi", "RSeparatePathPaste",    "sp", "<Cmd>lua require('r.path').separate('paste')")
     create_maps("nvi", "RSeparatePathHere",    "sh", "<Cmd>lua require('r.path').separate('here')")
 
-    create_maps("nvi", "RNumFormat",    "cn", "<Cmd>lua require('r.numformat').numformat()")
+    -- Format functions
+    create_maps("nvi", "RFormatNum",    "cn", "<Cmd>lua require('r.format').formatnum()")
 end
 
 local send = function(file_type)

--- a/lua/r/maps.lua
+++ b/lua/r/maps.lua
@@ -18,6 +18,7 @@ local map_desc = {
     RViewDFa            = { m = "", k = "", c = "Edit",     d = "View the head of a data.frame or matrix under cursor in a split window" },
     RShowEx             = { m = "", k = "", c = "Edit",     d = "Extract the Examples section and paste it in a split window" },
     RSeparatePathPaste  = { m = "", k = "", c = "Edit",     d = "Split the path of the file under the cursor and paste it using the paste() prefix function" },
+    RNumFormat          = { m = "", k = "", c = "Edit",     d = "Add an 'L' suffix after numbers to explicitly indicate them as integers." },
     RSeparatePathHere   = { m = "", k = "", c = "Edit",     d = "Split the path of the file under the cursor and open it using the here() prefix function" },
     RNextRChunk         = { m = "", k = "", c = "Navigate", d = "Go to the next chunk of R code" },
     RGoToTeX            = { m = "", k = "", c = "Navigate", d = "Go the corresponding line in the generated LaTeX document" },
@@ -141,9 +142,6 @@ local control = function(file_type)
     create_maps("v",   "RViewDF",           "rv", "<Cmd>lua require('r.run').action('viewobj', 'v')")
     create_maps("v",   "RDputObj",          "td", "<Cmd>lua require('r.run').action('dputtab', 'v')")
 
-    create_maps("nvi", "RSeparatePathPaste",    "sp", "<Cmd>lua require('r.path').separate('paste')")
-    create_maps("nvi", "RSeparatePathHere",    "sh", "<Cmd>lua require('r.path').separate('here')")
-
     if type(config.csv_app) == "function" or config.csv_app == "" then
         create_maps("ni",  "RViewDFs",          "vs", "<Cmd>lua require('r.run').action('viewobj', 'n', ', howto=\"split\"')")
         create_maps("ni",  "RViewDFv",          "vv", "<Cmd>lua require('r.run').action('viewobj', 'n', ', howto=\"vsplit\"')")
@@ -213,6 +211,11 @@ local edit = function()
         vim.api.nvim_buf_set_keymap(0, "i", config.pipe_keymap, "<Plug>RPipe", opts)
     end
     create_maps("nvi", "RSetwd", "rd", "<Cmd>lua require('r.run').setwd()")
+
+    create_maps("nvi", "RSeparatePathPaste",    "sp", "<Cmd>lua require('r.path').separate('paste')")
+    create_maps("nvi", "RSeparatePathHere",    "sh", "<Cmd>lua require('r.path').separate('here')")
+
+    create_maps("nvi", "RNumFormat",    "cn", "<Cmd>lua require('r.numformat').numformat()")
 end
 
 local send = function(file_type)
@@ -370,13 +373,10 @@ M.show_map_desc = function()
                     break
                 end
             end
-            table.insert(
-                map_key_desc,
-                {
-                    string.format("%-0" .. kw .. "s", keymap),
-                    keymap == "disabled" and "Comment" or "Special",
-                }
-            )
+            table.insert(map_key_desc, {
+                string.format("%-0" .. kw .. "s", keymap),
+                keymap == "disabled" and "Comment" or "Special",
+            })
             table.insert(map_key_desc, { v[4] .. "\n" })
         end
     end

--- a/lua/r/numformat.lua
+++ b/lua/r/numformat.lua
@@ -1,0 +1,66 @@
+local config = require("r.config").get_config()
+local M = {}
+
+-- We check if treesitter is available in the check_parsers() function of the
+-- R.nvim plugin, so we can safely require the parsers module here.
+local parsers = require("nvim-treesitter.parsers")
+
+-- Define the Treesitter query
+local query = [[
+((float) @value (#lua-match? @value "^%d+$"))
+]]
+
+local function is_adjacent_char_colon(bufnr, start_row, start_col, end_row, end_col)
+    -- Check if the previous or the next character is a colon in order to not add an "L" to the number. Should return only true or false
+    local prev_char = vim.api.nvim_buf_get_text(
+        bufnr,
+        start_row,
+        start_col - 1,
+        start_row,
+        start_col,
+        {}
+    )[1]
+
+    local next_char =
+        vim.api.nvim_buf_get_text(bufnr, end_row, end_col, end_row, end_col + 1, {})[1]
+
+    return prev_char == ":" or next_char == ":"
+end
+
+M.numformat = function(bufnr)
+    bufnr = bufnr or vim.api.nvim_get_current_buf()
+    local lang = parsers.get_buf_lang(bufnr)
+
+    if not lang then return end
+
+    local parser = parsers.get_parser(bufnr, lang)
+    local tree = parser:parse()[1]
+    local root = tree:root()
+
+    local query_obj = vim.treesitter.query.parse(lang, query)
+    -- local convert_range = config.convert_range_int
+
+    for _, node in query_obj:iter_captures(root, bufnr, 0, -1) do
+        local text = vim.treesitter.get_node_text(node, bufnr)
+
+        local start_row, start_col, end_row, end_col = node:range()
+
+        if
+            not (
+                is_adjacent_char_colon(bufnr, start_row, start_col, end_row, end_col)
+                and config.convert_range_int == false
+            )
+        then
+            vim.api.nvim_buf_set_text(
+                bufnr,
+                start_row,
+                start_col,
+                end_row,
+                end_col,
+                { text .. "L" }
+            )
+        end
+    end
+end
+
+return M


### PR DESCRIPTION
This PR introduces functionality for converting numbers to explicit integers in the current buffer. This feature is aimed at satisfying linters that recommend explicit integer usage, as detailed here: [Implicit Integer Linter](https://lintr.r-lib.org/reference/implicit_integer_linter.html?q=impl#ref-usage).

### Key Features:

- **New Keymap:** A new keymap (`<localleader>cn`, for change number) has been added for quickly converting numbers.
- **Configurable Option:** An option to avoid converting numbers in ranges (e.g., `1:10`) is available. By default, numbers within ranges are not converted, but this can be changed with the following configuration:

 ```lua
  convert_range_int = true
```

Maybe the default should be to `true`? 

###  Documentation

The documentation has been updated to reflect these changes.

