### PR TITLE
Automatically install missing packages in the current buffer

### DIFF
--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -1811,6 +1811,15 @@ configuration:
 `x[["a"]][["b"]][["c"]][["d"]]`. The default key binding for this is
 `<LocalLeader>cs` (change subsetting). 
 
+------------------------------------------------------------------------------
+6.37. Installing missing R packages in the current buffer     install_missing
+
+If the `lintr` package is installed and properly configured
+(https://github.com/R-nvim/R.nvim/wiki/lintr), it will mark any R packages
+used in the current buffer that are not installed as missing. These missing
+packages can be automatically installed using the `<LocalLeader>ip` (install
+packages) key binding.
+
 ==============================================================================
 7. Custom key bindings                                   *R.nvim-key-bindings*
 

--- a/lua/r/maps.lua
+++ b/lua/r/maps.lua
@@ -144,7 +144,7 @@ local control = function(file_type)
     create_maps("v",   "RViewDF",           "rv", "<Cmd>lua require('r.run').action('viewobj', 'v')")
     create_maps("v",   "RDputObj",          "td", "<Cmd>lua require('r.run').action('dputtab', 'v')")
 
-    create_maps("nvi", "RPackages",        "ip", "<Cmd>lua require('r.packages').install_missing_packages()")
+    create_maps("ni", "RPackages",          "ip", "<Cmd>lua require('r.packages').install_missing_packages()")
 
     if type(config.csv_app) == "function" or config.csv_app == "" then
         create_maps("ni",  "RViewDFs",          "vs", "<Cmd>lua require('r.run').action('viewobj', 'n', ', howto=\"split\"')")

--- a/lua/r/maps.lua
+++ b/lua/r/maps.lua
@@ -5,6 +5,7 @@ local warn = require("r").warn
 
 local map_desc = {
     RCustomStart        = { m = "", k = "", c = "Start",    d = "Ask user to enter parameters to start R" },
+    RPackages           = { m = "", k = "", c = "Start",    d = "Install missing package" },
     RSaveClose          = { m = "", k = "", c = "Start",    d = "Quit R, saving the workspace" },
     RClose              = { m = "", k = "", c = "Start",    d = "Send to R: quit(save = 'no')" },
     RStart              = { m = "", k = "", c = "Start",    d = "Start R with default configuration or reopen terminal window" },
@@ -141,6 +142,8 @@ local control = function(file_type)
     create_maps("v",   "RObjectStr",        "rt", "<Cmd>lua require('r.run').action('str', 'v')")
     create_maps("v",   "RViewDF",           "rv", "<Cmd>lua require('r.run').action('viewobj', 'v')")
     create_maps("v",   "RDputObj",          "td", "<Cmd>lua require('r.run').action('dputtab', 'v')")
+
+    create_maps("nvi", "RPackages",        "ip", "<Cmd>lua require('r.packages').install_missing_packages()")
 
     if type(config.csv_app) == "function" or config.csv_app == "" then
         create_maps("ni",  "RViewDFs",          "vs", "<Cmd>lua require('r.run').action('viewobj', 'n', ', howto=\"split\"')")

--- a/lua/r/packages.lua
+++ b/lua/r/packages.lua
@@ -18,8 +18,8 @@ end
 
 --- Installs missing R packages based on diagnostics from the linter
 --- Prompts the user for confirmation before proceeding with the installation
-M.install_missing_packages = function()
-    local bufnr = vim.api.nvim_get_current_buf()
+M.install_missing_packages = function(bufnr)
+    bufnr = bufnr or vim.api.nvim_get_current_buf()
     local diagnostics = vim.diagnostic.get(bufnr)
 
     if vim.tbl_isempty(diagnostics) then

--- a/lua/r/packages.lua
+++ b/lua/r/packages.lua
@@ -27,8 +27,13 @@ M.install_missing_packages = function(bufnr)
         return
     end
 
+    local target_codes = {
+        ["missing_package_linter"] = true,
+        ["namespace_linter"] = true,
+    }
+
     local missing_package_diagnostics = vim.tbl_filter(
-        function(diagnostic) return diagnostic.code == "missing_package_linter" end,
+        function(diagnostic) return target_codes[diagnostic.code] end,
         diagnostics
     )
 
@@ -44,12 +49,12 @@ M.install_missing_packages = function(bufnr)
 
     local msg = "Packages: "
         .. table.concat(missing_packages, ", ")
-        .. " are missing. Would you like to install them? (y/n)"
+        .. " are missing. Would you like to install them? (y/n): "
     vim.ui.input({ prompt = msg }, function(input)
         if input == "y" then
             S.cmd(rcmd)
         else
-            print("Not installing packages")
+            print("\nNot installing packages")
         end
     end)
 end

--- a/lua/r/packages.lua
+++ b/lua/r/packages.lua
@@ -1,0 +1,51 @@
+local M = {}
+local S = require("r.send")
+
+local function extract_package_name(message)
+    local package_name = message:match("Package '([^']+)'")
+    return package_name or "Package name not found"
+end
+
+-- Function to format packages as 'c("package1", "package2")'
+local function format_packages_list(package_list)
+    local formatted_string = 'c("' .. table.concat(package_list, '", "') .. '")'
+    return formatted_string
+end
+
+M.install_missing_packages = function()
+    local bufnr = vim.api.nvim_get_current_buf()
+    local diagnostics = vim.diagnostic.get(bufnr)
+
+    if vim.tbl_isempty(diagnostics) then
+        print("No diagnostics found under cursor")
+        return
+    end
+
+    local missing_package_diagnostics = vim.tbl_filter(
+        function(diagnostic) return diagnostic.code == "missing_package_linter" end,
+        diagnostics
+    )
+
+    local missing_packages = vim.tbl_map(
+        function(diagnostic) return extract_package_name(diagnostic.message) end,
+        missing_package_diagnostics
+    )
+
+    if vim.tbl_isempty(missing_packages) then return end
+
+    local formatted_packages_string = format_packages_list(missing_packages)
+    local rcmd = "install.packages(" .. formatted_packages_string .. ")"
+
+    local msg = "Packages: "
+        .. table.concat(missing_packages, ", ")
+        .. " are missing. Would you like to install them? (y/n)"
+    vim.ui.input({ prompt = msg }, function(input)
+        if input == "y" then
+            S.cmd(rcmd)
+        else
+            print("Not installing packages")
+        end
+    end)
+end
+
+return M

--- a/lua/r/packages.lua
+++ b/lua/r/packages.lua
@@ -4,8 +4,10 @@ local S = require("r.send")
 ---@param message string: The message containing the package name.
 ---@return string: The extracted package name or a default message if not found.
 local function extract_package_name(message)
-    local package_name = message:match("Package '([^']+)'")
-    return package_name or "Package name not found"
+    if message:find("is not installed") then
+        local package_name = message:match("Package '([^']+)'")
+        return package_name
+    end
 end
 
 --- Formats a list of package names into a string suitable for R's install.packages function

--- a/lua/r/packages.lua
+++ b/lua/r/packages.lua
@@ -1,17 +1,23 @@
 local M = {}
 local S = require("r.send")
 
+---@param message string: The message containing the package name.
+---@return string: The extracted package name or a default message if not found.
 local function extract_package_name(message)
     local package_name = message:match("Package '([^']+)'")
     return package_name or "Package name not found"
 end
 
--- Function to format packages as 'c("package1", "package2")'
+--- Formats a list of package names into a string suitable for R's install.packages function
+---@param package_list table: A list of package names to format
+---@return string: A formatted string of package names
 local function format_packages_list(package_list)
     local formatted_string = 'c("' .. table.concat(package_list, '", "') .. '")'
     return formatted_string
 end
 
+--- Installs missing R packages based on diagnostics from the linter
+--- Prompts the user for confirmation before proceeding with the installation
 M.install_missing_packages = function()
     local bufnr = vim.api.nvim_get_current_buf()
     local diagnostics = vim.diagnostic.get(bufnr)

--- a/lua/r/packages.lua
+++ b/lua/r/packages.lua
@@ -2,12 +2,13 @@ local M = {}
 local S = require("r.send")
 
 ---@param message string: The message containing the package name.
----@return string: The extracted package name or a default message if not found.
+---@return string|nil: The extracted package name or a default message if not found.
 local function extract_package_name(message)
     if message:find("is not installed") then
         local package_name = message:match("Package '([^']+)'")
         return package_name
     end
+    return nil
 end
 
 --- Formats a list of package names into a string suitable for R's install.packages function


### PR DESCRIPTION
This PR uses `lintr` to automatically install missing packages used in the current buffer. It will detect any missing packages used either as:

```r
library(package)
```
or as:

```r
package::fun()
```
