### PR TITLE
Fix new treesitter split path

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,13 @@ instructions on usage. See also the output of `:RMapsDesc`.
 
 ### Changes
 
-During the conversion of VimScript to Lua, we decided to end support for features
-that were useful in the past but no longer sufficiently valuable to be worth
-the effort of conversion. We removed support for `Rrst` (it seems that not
-many people use it anymore), debugging code (a debug adapter would be better),
-legacy omni-completion (auto completion with
-[nvim-cmp](https://github.com/hrsh7th/nvim-cmp) is better), and highlighting
-functions from .GlobalEnv (difficult to make compatible with tree-sitter + LSP
-highlighting).
+During the conversion of VimScript to Lua, we decided to end support for
+features that were useful in the past but no longer sufficiently valuable to
+be worth the effort of conversion. We removed support for `Rrst` (it seems
+that not many people use it anymore), legacy omni-completion (auto completion
+with [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) is better), and
+highlighting functions from .GlobalEnv (difficult to make compatible with
+tree-sitter + LSP highlighting).
 
 We changed the default key binding to insert the assignment operator (`<-`) from an
 underscore (which was familiar to Emacs-ESS users) to `Alt+-` which is more
@@ -127,9 +126,8 @@ sourced (`max_lines_to_paste`).
 The options for displaying R documentation (`nvimpager`) are now: `"split_h"`,
 `"split_v"`, `"tab"`, `"float"` (not implemented yet), and `"no"`.
 
-The options `openpdf` and `openhtml` were renamed as `open_pdf` and
-`open_html`, they now are strings and there with a minor change in how they
-behave.
+The options `openpdf` and `openhtml` were renamed as `open_pdf` and `open_html`,
+they now are strings and there was with a minor change in how they behave.
 
 The option `nvim_wd` was renamed as `setwd` and it now is a string and its
 default value is "no".

--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -59,6 +59,7 @@ Git pull requests are welcome.
       - Syntax highlighting of the Object Browser.
   * SyncTeX support for Rnoweb.
   * Special highlighting for R output (.Rout files).
+  * Limited support for debugging R functions.
   * Most of the plugin's behavior is customizable.
 
 
@@ -549,6 +550,78 @@ put in your `init.lua`:
    vim.g.rout_follow_colorscheme = true
 <
 
+------------------------------------------------------------------------------
+4.7. Debugging R functions (Unix only)                     *debug-R-functions*
+
+The R-Nvim-Plugin has limited debugging facilities available on Unix systems
+(not available on Windows). To debug a function with R-Nvim you have to do the
+following:
+
+   1. Source the R script where the function is with the `source()` function
+      of the `base` package.
+
+   2. In the R Console, run either `debug(funcname)` or `debugonce(funcname)`
+      where `funcname` is the name of the function (not quoted). R-Nvim will
+      send this command to R Console if you press <LocalLeader>db in Normal
+      mode with the cursor over the function name.
+
+   3. Call the function.
+
+See `:Rh browser` for available commands in debugging mode.
+
+For example, if you have a file named `my_function.R` with the following
+contents:
+>r
+   add.one <- function(x){
+       y <- x + 1
+       print(y)
+       return(invisible(NULL))
+   }
+<
+You could debug the `add.one()` function from another script such as:
+>r
+   source("path/to/my_function.R")
+   debug(add.one)
+   add.one(7)
+<
+If you do not want to start debugging the function from its first line,
+instead of calling `debug(funcname)` before calling the function, you should
+add the line `browser()` to the function at the line where the debugging
+session should start. Example:
+>r
+   add.one <- function(x){
+       y <- x + 1
+       browser()
+       print(y)
+       return(invisible(NULL))
+   }
+<
+If you want a conditional breakpoint, you should call the `browser()` command
+only if a condition is satisfied. Example:
+>r
+   add.one <- function(x){
+       y <- x + 1
+       if(x > 9)
+           browser()
+       print(y)
+       return(invisible(NULL))
+   }
+<
+One limitation is that R-Nvim also does not help you setting breakpoints.
+You have to set them manually as explained above.
+
+Another limitation of R-Nvim is that it might be unable to jump to the line in
+the source code that is being evaluated if either you have sent the function
+directly to the R Console or the function has been sent by the `knitr`
+package, without calling the function `source()`. In either case, R-Nvim will
+try to find the pattern `funcname <- function(` in the buffer being edited. If
+the pattern is found, the cursor will jump to its position.
+
+The highlighting group used to highlight the line being debugged is the
+QuickFixLine (see |hl-QuickFixLine|). Its foreground and background colors are
+defined by your colorscheme.
+
+
 ==============================================================================
 5. Known bugs and workarounds                              *R.nvim-known-bugs*
 
@@ -710,6 +783,7 @@ command:
 |wait_reply|          Time to wait for R reply
 |setwd|               Directory where to start R
 |hook|                Lua functions to call after certain events
+|debug|             Support for debugging functions
 |user_maps_only|      Only user specified key bindings
 |disable_cmds|        List of commands to be disabled
 |tmpdir|              Where temporary files are created
@@ -1809,7 +1883,7 @@ configuration:
 `R.nvim` also also convert the subsetting operator `$` to `[[`. For example,
 `x$a` will be converted to `x[["a"]]` and `x$a$b$c$d` will be converted to
 `x[["a"]][["b"]][["c"]][["d"]]`. The default key binding for this is
-`<LocalLeader>cs` (change subsetting). 
+`<LocalLeader>cs` (change subsetting).
 
 
 ------------------------------------------------------------------------------
@@ -1821,6 +1895,27 @@ used in the current buffer that are not installed as missing. These missing
 packages can be automatically installed using the `<LocalLeader>ip` (install
 packages) key binding.
 
+
+------------------------------------------------------------------------------
+6.38. Support for debugging functions                                *debug*
+
+Put the line below in your config if do not want that the cursor jumps to the
+line being debugged (when `browser()` is run). Highlighting of the line being
+debugged will also be disabled.
+>lua
+   debug = false
+<
+R-Nvim puts the cursor in the R Console when the debugging starts. If you do
+not want this, put in your config:
+>lua
+   dbg_jump = false
+<
+The highlighted debugged line incrementally moves down the buffer with code
+execution and, with long scripts, it may stay at the bottom of the window as you
+debug. You can hold the highlighted line in the middle of the window with
+>lua
+    debug_center = true
+<
 
 ==============================================================================
 7. Custom key bindings                                   *R.nvim-key-bindings*

--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -553,21 +553,21 @@ put in your `init.lua`:
 ------------------------------------------------------------------------------
 4.7. Debugging R functions (Unix only)                     *debug-R-functions*
 
-The R-Nvim-Plugin has limited debugging facilities available on Unix systems
-(not available on Windows). To debug a function with R-Nvim you have to do the
+`R.nvim` has limited debugging facilities available on Unix systems (not
+available on Windows). To debug a function with R.nvim you have to do the
 following:
 
    1. Source the R script where the function is with the `source()` function
       of the `base` package.
 
    2. In the R Console, run either `debug(funcname)` or `debugonce(funcname)`
-      where `funcname` is the name of the function (not quoted). R-Nvim will
+      where `funcname` is the name of the function (not quoted). R.nvim will
       send this command to R Console if you press <LocalLeader>db in Normal
       mode with the cursor over the function name.
 
    3. Call the function.
 
-See `:Rh browser` for available commands in debugging mode.
+See `:RHelp browser` for available commands in debugging mode.
 
 For example, if you have a file named `my_function.R` with the following
 contents:
@@ -607,13 +607,13 @@ only if a condition is satisfied. Example:
        return(invisible(NULL))
    }
 <
-One limitation is that R-Nvim also does not help you setting breakpoints.
+One limitation is that R.nvim also does not help you setting breakpoints.
 You have to set them manually as explained above.
 
-Another limitation of R-Nvim is that it might be unable to jump to the line in
+Another limitation of R.nvim is that it might be unable to jump to the line in
 the source code that is being evaluated if either you have sent the function
 directly to the R Console or the function has been sent by the `knitr`
-package, without calling the function `source()`. In either case, R-Nvim will
+package, without calling the function `source()`. In either case, R.nvim will
 try to find the pattern `funcname <- function(` in the buffer being edited. If
 the pattern is found, the cursor will jump to its position.
 
@@ -1905,7 +1905,7 @@ debugged will also be disabled.
 >lua
    debug = false
 <
-R-Nvim puts the cursor in the R Console when the debugging starts. If you do
+R.nvim puts the cursor in the R Console when the debugging starts. If you do
 not want this, put in your config:
 >lua
    dbg_jump = false

--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -1913,7 +1913,7 @@ debugged will also be disabled.
 R.nvim puts the cursor in the R Console when the debugging starts. If you do
 not want this, put in your config:
 >lua
-   dbg_jump = false
+   debug_jump = false
 <
 The highlighted debugged line incrementally moves down the buffer with code
 execution and, with long scripts, it may stay at the bottom of the window as you

--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -557,13 +557,18 @@ put in your `init.lua`:
 available on Windows). To debug a function with R.nvim you have to do the
 following:
 
-   1. Source the R script where the function is with the `source()` function
-      of the `base` package.
+   1. Load the functions into R either by a) sourcing the R script where the
+      function is with the `source()` function of the `base` package or b)
+      loading all desired functions with `devtools::load_all(<relevant path>)`.
 
-   2. In the R Console, run either `debug(funcname)` or `debugonce(funcname)`
+   2. Flag a function or line of code within a function to use the debugger.
+      This can be done by using the `debug` functions or setting a breakpoint
+      with the `browser` functions from the `base` package. To use `debug`,
+      in the R Console, run either `debug(funcname)` or `debugonce(funcname)`
       where `funcname` is the name of the function (not quoted). R.nvim will
       send this command to R Console if you press <LocalLeader>db in Normal
-      mode with the cursor over the function name.
+      mode with the cursor over the function name. An example of using
+      `browser` is shown later in the documentation.
 
    3. Call the function.
 

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -33,6 +33,8 @@ local config = {
     },
     config_tmux         = true,
     csv_app             = "",
+    debug_center        = false,
+    debug_jump          = true,
     disable_cmds        = { "" },
     editing_mode        = "",
     esc_term            = true,

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -33,6 +33,7 @@ local config = {
     },
     config_tmux         = true,
     csv_app             = "",
+    debug               = true,
     debug_center        = false,
     debug_jump          = true,
     disable_cmds        = { "" },

--- a/lua/r/debug.lua
+++ b/lua/r/debug.lua
@@ -23,6 +23,7 @@ local s = {
     bufnr = -1,
     winnr = -1,
     func_offset = -2, -- Did not seek yet
+    fnm = ""
 }
 
 local find_func = function(srcref)
@@ -79,6 +80,7 @@ M.stop = function()
         debugging = false,
         bufnr = -1,
         func_offset = -2, -- Did not seek yet
+        fnm = ""
     }
 end
 
@@ -86,8 +88,9 @@ end
 ---@param fnm string The file name
 ---@param lnum number The line number
 M.jump = function(fnm, lnum)
-    -- Open the R script where the function is if not open yet
-    if not s.debugging then
+    -- Open function's script is if not open yet
+    if not s.debugging or s.fnm ~= fnm then
+        s.fnm = fnm
         if fnm == "" or fnm == "<text>" then
             --- Functions sent directly to R Console have no associated source file
             --- and functions sourced by knitr have '<text>' as source reference.

--- a/lua/r/debug.lua
+++ b/lua/r/debug.lua
@@ -81,7 +81,6 @@ M.find_debug_func = function(srcref)
     isnormal = vim.fn.mode() == "n"
     if isnormal then vim.cmd("stopinsert") end
 
-    sbopt = vim.o.switchbuf
     vim.o.switchbuf = sbopt
 end
 
@@ -113,11 +112,7 @@ M.r_debug_jump = function(fnm, lnum)
         and fname ~= vim.fn.expand("%")
         and fname ~= vim.fn.expand("%:p")
     then
-        if vim.fn.filereadable(fname) == 1 then
-            vim.cmd("sb " .. vim.fn.luaeval('require("r.edit").get_rscript_name()'))
-            if vim.bo.modified then vim.cmd("split") end
-            vim.cmd("edit " .. fname)
-        elseif vim.fn.glob("*") == fname then
+        if vim.fn.filereadable(fname) == 1 or vim.fn.glob("*") == fname then
             vim.cmd("sb " .. vim.fn.luaeval('require("r.edit").get_rscript_name()'))
             if vim.bo.modified then vim.cmd("split") end
             vim.cmd("edit " .. fname)

--- a/lua/r/debug.lua
+++ b/lua/r/debug.lua
@@ -74,6 +74,14 @@ local find_func = function(srcref)
     end
 end
 
+local switch_buf = function(fnm)
+    vim.cmd("sb " .. vim.fn.bufname(require("r.edit").get_rscript_buf()))
+    if vim.bo.modified then vim.cmd("split") end
+    vim.cmd("edit " .. fnm)
+    s.bufnr = vim.api.nvim_get_current_buf()
+    s.winnr = vim.api.nvim_get_current_win()
+end
+
 M.stop = function()
     vim.fn.sign_unplace("rnvim_dbgline", { id = 1 })
     s = {
@@ -100,18 +108,12 @@ M.jump = function(fnm, lnum)
             local fname = vim.fn.expand(fnm)
             if vim.fn.bufloaded(fname) == 0 then
                 if vim.fn.filereadable(fname) == 1 or vim.fn.glob("*") == fname then
-                    vim.cmd("sb " .. vim.fn.bufname(require("r.edit").get_rscript_buf()))
-                    if vim.bo.modified then vim.cmd("split") end
-                    vim.cmd("edit " .. fname)
-                    s.bufnr = vim.api.nvim_get_current_buf()
-                    s.winnr = vim.api.nvim_get_current_win()
+                    switch_buf(fname)
                 else
                     return
                 end
             else
-                vim.cmd("sb " .. fname)
-                s.bufnr = vim.api.nvim_get_current_buf()
-                s.winnr = vim.api.nvim_get_current_win()
+                switch_buf(fname)
             end
         end
     end

--- a/lua/r/debug.lua
+++ b/lua/r/debug.lua
@@ -1,0 +1,152 @@
+------------------------------------------------------------------------------
+-- Support for debugging R code
+------------------------------------------------------------------------------
+local config = require("r.config").get_config()
+
+local r_bufnr
+local M = {}
+
+-- Handle ambiwidth option and define signs
+if vim.o.ambiwidth == "double" then
+    vim.fn.sign_define(
+        "dbgline",
+        { text = "==>", texthl = "SignColumn", linehl = "QuickFixLine" }
+    )
+else
+    vim.fn.sign_define(
+        "dbgline",
+        { text = "▬▶", texthl = "SignColumn", linehl = "QuickFixLine" }
+    )
+end
+
+local s = {
+    func_offset = -2, -- Did not seek yet
+    rdebugging = 0
+}
+
+M.stop_r_debugging = function()
+    vim.fn.sign_unplace("rnvim_dbgline", { id = 1 })
+    s.func_offset = -2
+    s.rdebugging = 0
+end
+
+M.find_debug_func = function(srcref)
+    local rlines
+    local can_debug = type(config.external_term) == "boolean" and not config.external_term
+    if not can_debug then return end
+
+    s.func_offset = -1 -- Not found
+    local sbopt = vim.o.switchbuf
+    vim.o.switchbuf = "useopen,usetab"
+    local curtab = vim.fn.tabpagenr()
+    local isnormal = vim.fn.mode() == "n"
+    local curwin = vim.fn.winnr()
+    r_bufnr = vim.api.nvim_get_current_buf()
+    vim.cmd("sb " .. r_bufnr)
+    vim.fn.sleep(30) -- Time to fill the buffer lines
+    rlines = vim.fn.getline(1, "$")
+    vim.cmd("sb " .. vim.fn.luaeval('require("r.edit").get_rscript_name()'))
+
+    local idx = #rlines - 1
+    while idx > 0 do
+        if string.match(rlines[idx], "^debugging in: ") then
+            local funcnm = string.gsub(rlines[idx], "^debugging in: %(.{-}%)%((.*)", "%1")
+            s.func_offset =
+                vim.fn.search(".*\\<" .. funcnm .. "\\s*<-\\s*function\\s*(", "b")
+            if s.func_offset < 1 then
+                s.func_offset =
+                    vim.fn.search(".*\\<" .. funcnm .. "\\s*=\\s*function\\s*(", "b")
+            end
+            if s.func_offset < 1 then
+                s.func_offset =
+                    vim.fn.search(".*\\<" .. funcnm .. "\\s*<<-\\s*function\\s*(", "b")
+            end
+            if s.func_offset > 0 then s.func_offset = s.func_offset - 1 end
+            if srcref == "<text>" then
+                if vim.bo.filetype == "rmd" or vim.bo.filetype == "quarto" then
+                    s.func_offset = vim.fn.search("^\\s*```\\s*{\\s*r", "nb")
+                elseif vim.bo.filetype == "rnoweb" then
+                    s.func_offset = vim.fn.search("^<<", "nb")
+                end
+            end
+            break
+        end
+        idx = idx - 1
+    end
+
+    curtab = vim.fn.tabpagenr()
+    if vim.fn.tabpagenr() ~= curtab then vim.cmd("normal! " .. curtab .. "gt") end
+    curwin = vim.fn.winnr()
+    vim.cmd(curwin .. "wincmd w")
+    isnormal = vim.fn.mode() == "n"
+    if isnormal then vim.cmd("stopinsert") end
+
+    sbopt = vim.o.switchbuf
+    vim.o.switchbuf = sbopt
+end
+
+M.r_debug_jump = function(fnm, lnum)
+    local saved_so = vim.o.scrolloff
+    if config.debug_center then vim.o.scrolloff = 999 end
+
+    if fnm == "" or fnm == "<text>" then
+        --- Functions sent directly to R Console have no associated source file
+        --- and functions sourced by knitr have '<text>' as source reference.
+        if s.func_offset == -2 then M.find_debug_func(fnm) end
+        if s.func_offset < 0 then return end
+    end
+
+    local flnum, fname
+    if s.func_offset >= 0 then
+        flnum = lnum + s.func_offset
+        fname = vim.fn.luaeval('require("r.edit").get_rscript_name()')
+    else
+        flnum = lnum
+        fname = vim.fn.expand(fnm)
+    end
+
+    local bname = vim.fn.bufname("%")
+
+    if
+        not vim.fn.bufloaded(fname)
+        and fname ~= vim.fn.luaeval('require("r.edit").get_rscript_name()')
+        and fname ~= vim.fn.expand("%")
+        and fname ~= vim.fn.expand("%:p")
+    then
+        if vim.fn.filereadable(fname) == 1 then
+            vim.cmd("sb " .. vim.fn.luaeval('require("r.edit").get_rscript_name()'))
+            if vim.bo.modified then vim.cmd("split") end
+            vim.cmd("edit " .. fname)
+        elseif vim.fn.glob("*") == fname then
+            vim.cmd("sb " .. vim.fn.luaeval('require("r.edit").get_rscript_name()'))
+            if vim.bo.modified then vim.cmd("split") end
+            vim.cmd("edit " .. fname)
+        else
+            return
+        end
+    end
+
+    if vim.fn.bufloaded(fname) == 1 then
+        if fname ~= vim.fn.expand("%") then vim.cmd("sb " .. fname) end
+        vim.cmd(":" .. flnum)
+    end
+
+    r_bufnr = vim.api.nvim_get_current_buf()
+    vim.fn.sign_unplace("rnvim_dbgline", { id = 1 })
+    vim.fn.sign_place(1, "rnvim_dbgline", "dbgline", r_bufnr, { lnum = flnum })
+    if
+        config.debug_jump
+        and not s.rdebugging
+        and type(config.external_term) == "boolean"
+        and not config.external_term
+    then
+        vim.cmd("sb " .. r_bufnr)
+        vim.cmd("startinsert")
+    elseif bname ~= vim.fn.expand("%") then
+        vim.cmd("sb " .. bname)
+    end
+    s.rdebugging = 1
+    vim.o.scrolloff = saved_so
+end
+
+return M

--- a/lua/r/debug.lua
+++ b/lua/r/debug.lua
@@ -23,7 +23,7 @@ local s = {
     bufnr = -1,
     winnr = -1,
     func_offset = -2, -- Did not seek yet
-    fnm = ""
+    fnm = "",
 }
 
 local find_func = function(srcref)
@@ -34,7 +34,15 @@ local find_func = function(srcref)
     if type(config.external_term) == "boolean" and not config.external_term then
         rlines = vim.api.nvim_buf_get_lines(require("r.term").get_buf_nr(), 0, -1, false)
     else
-        local run_cmd = { "tmux", "-L", "Rnvim", "capture-pane", "-p", "-t", require("r.external_term").get_tmuxsname() }
+        local run_cmd = {
+            "tmux",
+            "-L",
+            "Rnvim",
+            "capture-pane",
+            "-p",
+            "-t",
+            require("r.external_term").get_tmuxsname(),
+        }
         local resp = require("r.utils").system(run_cmd, { text = true }):wait()
         rlines = vim.split(resp.stdout, "\n")
     end
@@ -51,10 +59,8 @@ local find_func = function(srcref)
                     vim.fn.search(".*\\<" .. func_name .. "\\s*=\\s*function\\s*(", "b")
             end
             if s.func_offset < 1 then
-                s.func_offset = vim.fn.search(
-                    ".*\\<" .. func_name .. "\\s*<<-\\s*function\\s*(",
-                    "b"
-                )
+                s.func_offset =
+                    vim.fn.search(".*\\<" .. func_name .. "\\s*<<-\\s*function\\s*(", "b")
             end
             if s.func_offset > 0 then
                 s.bufnr = vim.api.nvim_get_current_buf()
@@ -90,7 +96,7 @@ M.stop = function()
         debugging = false,
         bufnr = -1,
         func_offset = -2, -- Did not seek yet
-        fnm = ""
+        fnm = "",
     }
 end
 
@@ -130,26 +136,23 @@ M.jump = function(fnm, lnum)
         end
 
         local saved_so = vim.o.scrolloff
-        if config.debug_center then
-            vim.o.scrolloff = 999
-        end
+        if config.debug_center then vim.o.scrolloff = 999 end
         vim.api.nvim_win_set_cursor(s.winnr, { flnum, 0 })
-        if config.debug_center then
-            vim.o.scrolloff = saved_so
-        end
+        if config.debug_center then vim.o.scrolloff = saved_so end
 
         vim.fn.sign_unplace("rnvim_dbgline", { id = 1 })
         vim.fn.sign_place(1, "rnvim_dbgline", "dbgline", s.bufnr, { lnum = flnum })
     end
 
-    if config.debug_jump
+    if
+        config.debug_jump
         and type(config.external_term) == "boolean"
         and not config.external_term
         and vim.api.nvim_get_current_buf() ~= require("r.term").get_buf_nr()
-        then
-            vim.cmd("sb " .. tostring(require("r.term").get_buf_nr()))
-            vim.cmd("startinsert")
-        end
+    then
+        vim.cmd("sb " .. tostring(require("r.term").get_buf_nr()))
+        vim.cmd("startinsert")
+    end
 
     s.debugging = true
 end

--- a/lua/r/debug.lua
+++ b/lua/r/debug.lua
@@ -3,7 +3,6 @@
 ------------------------------------------------------------------------------
 local config = require("r.config").get_config()
 
-local r_bufnr
 local M = {}
 
 -- Handle ambiwidth option and define signs
@@ -20,131 +19,132 @@ else
 end
 
 local s = {
+    debugging = false,
+    bufnr = -1,
+    winnr = -1,
     func_offset = -2, -- Did not seek yet
-    rdebugging = 0
 }
 
 local find_func = function(srcref)
     local rlines
-    -- local can_debug = type(config.external_term) == "boolean" and not config.external_term
-    -- if not can_debug then return end
-
     s.func_offset = -1 -- Not found
-    local sbopt = vim.o.switchbuf
-    vim.o.switchbuf = "useopen,usetab"
-    local curtab = vim.fn.tabpagenr()
-    local isnormal = vim.fn.mode() == "n"
-    local curwin = vim.fn.winnr()
-    r_bufnr = vim.api.nvim_get_current_buf()
-    vim.cmd("sb " .. r_bufnr)
-    -- vim.fn.sleep(30) -- Time to fill the buffer lines
-    rlines = vim.fn.getline(1, "$")
-    vim.cmd("sb " .. vim.fn.bufname(require("r.edit").get_rscript_buf()))
+
+    vim.wait(300)
+    if type(config.external_term) == "boolean" and not config.external_term then
+        rlines = vim.api.nvim_buf_get_lines(require("r.term").get_buf_nr(), 0, -1, false)
+    else
+        local run_cmd = { "tmux", "-L", "Rnvim", "capture-pane", "-p", "-t", require("r.external_term").get_tmuxsname() }
+        local resp = require("r.utils").system(run_cmd, { text = true }):wait()
+        rlines = vim.split(resp.stdout, "\n")
+    end
 
     local idx = #rlines - 1
     while idx > 0 do
         if string.match(rlines[idx], "^debugging in: ") then
-            local funcnm = string.gsub(rlines[idx], "^debugging in: %(.{-}%)%((.*)", "%1")
+            local func_name = string.gsub(rlines[idx], "debugging in: ", "")
+            func_name = string.gsub(func_name, "%(.*", "")
             s.func_offset =
-                vim.fn.search(".*\\<" .. funcnm .. "\\s*<-\\s*function\\s*(", "b")
+                vim.fn.search(".*\\<" .. func_name .. "\\s*<-\\s*function\\s*(", "b")
             if s.func_offset < 1 then
                 s.func_offset =
-                    vim.fn.search(".*\\<" .. funcnm .. "\\s*=\\s*function\\s*(", "b")
+                    vim.fn.search(".*\\<" .. func_name .. "\\s*=\\s*function\\s*(", "b")
             end
             if s.func_offset < 1 then
-                s.func_offset =
-                    vim.fn.search(".*\\<" .. funcnm .. "\\s*<<-\\s*function\\s*(", "b")
+                s.func_offset = vim.fn.search(
+                    ".*\\<" .. func_name .. "\\s*<<-\\s*function\\s*(",
+                    "b"
+                )
             end
-            if s.func_offset > 0 then s.func_offset = s.func_offset - 1 end
-            if srcref == "<text>" then
-                if vim.bo.filetype == "rmd" or vim.bo.filetype == "quarto" then
-                    s.func_offset = vim.fn.search("^\\s*```\\s*{\\s*r", "nb")
-                elseif vim.bo.filetype == "rnoweb" then
-                    s.func_offset = vim.fn.search("^<<", "nb")
+            if s.func_offset > 0 then
+                s.bufnr = vim.api.nvim_get_current_buf()
+                s.winnr = vim.api.nvim_get_current_win()
+                s.func_offset = s.func_offset - 1
+                if srcref == "<text>" then
+                    if vim.bo.filetype == "rmd" or vim.bo.filetype == "quarto" then
+                        s.func_offset = vim.fn.search("^\\s*```\\s*{\\s*r", "nb")
+                    elseif vim.bo.filetype == "rnoweb" then
+                        s.func_offset = vim.fn.search("^<<", "nb")
+                    end
                 end
             end
             break
         end
         idx = idx - 1
     end
-
-    curtab = vim.fn.tabpagenr()
-    if vim.fn.tabpagenr() ~= curtab then vim.cmd("normal! " .. curtab .. "gt") end
-    curwin = vim.fn.winnr()
-    vim.cmd(curwin .. "wincmd w")
-    isnormal = vim.fn.mode() == "n"
-    if isnormal then vim.cmd("stopinsert") end
-
-    vim.o.switchbuf = sbopt
 end
 
 M.stop = function()
     vim.fn.sign_unplace("rnvim_dbgline", { id = 1 })
-    s.func_offset = -2
-    s.rdebugging = 0
+    s = {
+        debugging = false,
+        bufnr = -1,
+        func_offset = -2, -- Did not seek yet
+    }
 end
 
 --- Jump to line being evaluated
 ---@param fnm string The file name
 ---@param lnum number The line number
 M.jump = function(fnm, lnum)
-    local saved_so = vim.o.scrolloff
-    if config.debug_center then vim.o.scrolloff = 999 end
-
-    if fnm == "" or fnm == "<text>" then
-        --- Functions sent directly to R Console have no associated source file
-        --- and functions sourced by knitr have '<text>' as source reference.
-        if s.func_offset == -2 then find_func(fnm) end
-        if s.func_offset < 0 then return end
-    end
-
-    local flnum, fname
-    if s.func_offset >= 0 then
-        flnum = lnum + s.func_offset
-        fname = vim.fn.bufname(require("r.edit").get_rscript_buf())
-    else
-        flnum = lnum
-        fname = vim.fn.expand(fnm)
-    end
-
-    if
-        vim.fn.bufloaded(fname) == 0
-        and fname ~= vim.fn.bufname(require("r.edit").get_rscript_buf())
-        and fname ~= vim.fn.expand("%")
-        and fname ~= vim.fn.expand("%:p")
-    then
-        if vim.fn.filereadable(fname) == 1 or vim.fn.glob("*") == fname then
-            vim.cmd("sb " .. vim.fn.bufname(require("r.edit").get_rscript_buf()))
-            if vim.bo.modified then vim.cmd("split") end
-            vim.cmd("edit " .. fname)
+    -- Open the R script where the function is if not open yet
+    if not s.debugging then
+        if fnm == "" or fnm == "<text>" then
+            --- Functions sent directly to R Console have no associated source file
+            --- and functions sourced by knitr have '<text>' as source reference.
+            if s.func_offset == -2 then find_func(fnm) end
+            if s.func_offset < 0 then return end
         else
-            return
+            local fname = vim.fn.expand(fnm)
+            if vim.fn.bufloaded(fname) == 0 then
+                if vim.fn.filereadable(fname) == 1 or vim.fn.glob("*") == fname then
+                    vim.cmd("sb " .. vim.fn.bufname(require("r.edit").get_rscript_buf()))
+                    if vim.bo.modified then vim.cmd("split") end
+                    vim.cmd("edit " .. fname)
+                    s.bufnr = vim.api.nvim_get_current_buf()
+                    s.winnr = vim.api.nvim_get_current_win()
+                else
+                    return
+                end
+            else
+                vim.cmd("sb " .. fname)
+                s.bufnr = vim.api.nvim_get_current_buf()
+                s.winnr = vim.api.nvim_get_current_win()
+            end
         end
     end
 
-    if vim.fn.bufloaded(fname) == 1 then
-        if fname ~= vim.fn.expand("%") then vim.cmd("sb " .. fname) end
-        vim.cmd(":" .. flnum)
+    -- Move the cursor and highlight its line
+    if vim.fn.bufloaded(s.bufnr) == 1 then
+        local flnum
+        if s.func_offset >= 0 then
+            flnum = lnum + s.func_offset
+        else
+            flnum = lnum
+        end
+
+        local saved_so = vim.o.scrolloff
+        if config.debug_center then
+            vim.o.scrolloff = 999
+        end
+        vim.api.nvim_win_set_cursor(s.winnr, { flnum, 0 })
+        if config.debug_center then
+            vim.o.scrolloff = saved_so
+        end
+
+        vim.fn.sign_unplace("rnvim_dbgline", { id = 1 })
+        vim.fn.sign_place(1, "rnvim_dbgline", "dbgline", s.bufnr, { lnum = flnum })
     end
 
-    local bname = vim.fn.bufname("%")
-
-    r_bufnr = vim.api.nvim_get_current_buf()
-    vim.fn.sign_unplace("rnvim_dbgline", { id = 1 })
-    vim.fn.sign_place(1, "rnvim_dbgline", "dbgline", r_bufnr, { lnum = flnum })
-    if
-        config.debug_jump
-        and not s.rdebugging
+    if config.debug_jump
         and type(config.external_term) == "boolean"
         and not config.external_term
-    then
-        vim.cmd("sb " .. r_bufnr)
-        vim.cmd("startinsert")
-    elseif bname ~= vim.fn.expand("%") then
-        vim.cmd("sb " .. bname)
-    end
-    s.rdebugging = 1
-    vim.o.scrolloff = saved_so
+        and vim.api.nvim_get_current_buf() ~= require("r.term").get_buf_nr()
+        then
+            vim.cmd("sb " .. tostring(require("r.term").get_buf_nr()))
+            vim.cmd("startinsert")
+        end
+
+    s.debugging = true
 end
 
 return M

--- a/lua/r/debug.lua
+++ b/lua/r/debug.lua
@@ -75,7 +75,9 @@ local find_func = function(srcref)
 end
 
 local switch_buf = function(fnm)
-    vim.cmd("sb " .. vim.fn.bufname(require("r.edit").get_rscript_buf()))
+    if vim.api.nvim_get_current_buf() ~= require("r.edit").get_rscript_buf() then
+        vim.cmd("sb " .. tostring(require("r.edit").get_rscript_buf()))
+    end
     if vim.bo.modified then vim.cmd("split") end
     vim.cmd("edit " .. fnm)
     s.bufnr = vim.api.nvim_get_current_buf()

--- a/lua/r/external_term.lua
+++ b/lua/r/external_term.lua
@@ -257,4 +257,8 @@ M.send_cmd_to_external_term = function(command)
     return true
 end
 
+--- Return Tmux target name
+---@return string
+M.get_tmuxsname = function() return tmuxsname end
+
 return M

--- a/lua/r/maps.lua
+++ b/lua/r/maps.lua
@@ -55,6 +55,8 @@ local map_desc = {
     RShowRout           = { m = "", k = "", c = "Command",  d = "R CMD BATCH the current document and show the output in a new tab" },
     RSPlot              = { m = "", k = "", c = "Command",  d = "Send to R command to run summary and plot with <cword> as argument" },
     RClearConsole       = { m = "", k = "", c = "Command",  d = "Send to R: <Ctrl-L>" },
+    RDebug              = { m = "", k = "", c = "Command",  d = "Send to R: debug" },
+    RUndebug            = { m = "", k = "", c = "Command",  d = "Send to R: undebug" },
     RListSpace          = { m = "", k = "", c = "Command",  d = "Send to R: ls()" },
     RShowArgs           = { m = "", k = "", c = "Command",  d = "Send to R: nvim.args(<cword>)" },
     RObjectNames        = { m = "", k = "", c = "Command",  d = "Send to R: nvim.names(<cword>)" },
@@ -164,10 +166,14 @@ local control = function(file_type)
     create_maps("ni",  "RSummary",          "rs", "<Cmd>lua require('r.run').action('summary')")
     create_maps("ni",  "RPlot",             "rg", "<Cmd>lua require('r.run').action('plot')")
     create_maps("ni",  "RSPlot",            "rb", "<Cmd>lua require('r.run').action('plotsumm')")
+    create_maps("ni",  "RDebug",            "bg", "<Cmd>lua require('r.run').action('debug')")
+    create_maps("ni",  "RUndebug",          "ud", "<Cmd>lua require('r.run').action('undebug')")
 
     create_maps("v",   "RSummary",          "rs", "<Cmd>lua require('r.run').action('summary', 'v')")
     create_maps("v",   "RPlot",             "rg", "<Cmd>lua require('r.run').action('plot', 'v')")
     create_maps("v",   "RSPlot",            "rb", "<Cmd>lua require('r.run').action('plotsumm', 'v')")
+    create_maps("v",   "RDebug",            "bg", "<Cmd>lua require('r.run').action('debug', 'v')")
+    create_maps("v",   "RUndebug",          "ud", "<Cmd>lua require('r.run').action('undebug', 'v')")
 
     -- Object Browser
     create_maps("nvi", "ROBToggle",         "ro", "<Cmd>lua require('r.browser').start()")

--- a/lua/r/path.lua
+++ b/lua/r/path.lua
@@ -36,10 +36,16 @@ local function replace_path(node, formatted_path)
 end
 
 M.separate = function(prefix)
+    local path
     local node = vim.treesitter.get_node()
 
-    if node and node:type() == "string" then
-        local path = vim.treesitter.get_node_text(node, 0)
+    if node and node:type() == "string_content" then
+        local parent_node = node:parent()
+        if parent_node then
+            path = vim.treesitter.get_node_text(parent_node, 0)
+        else
+            return
+        end
 
         -- Check if the path is a URL or doesn't contain slashes
         if
@@ -72,7 +78,7 @@ M.separate = function(prefix)
             formatted_path = 'here("' .. formatted_path .. '")'
         end
 
-        replace_path(node, formatted_path)
+        replace_path(node:parent(), formatted_path)
     end
 end
 

--- a/lua/r/run.lua
+++ b/lua/r/run.lua
@@ -64,6 +64,11 @@ start_R2 = function()
         start_options,
         "options(nvimcom.max_time = " .. tostring(config.compl_data.max_time) .. ")"
     )
+    if config.debug then
+        table.insert(start_options, "options(nvimcom.debug_r = TRUE)")
+    else
+        table.insert(start_options, "options(nvimcom.debug_r = FALSE)")
+    end
     if config.objbr_allnames then
         table.insert(start_options, "options(nvimcom.allnames = TRUE)")
     else
@@ -81,6 +86,8 @@ start_R2 = function()
     else
         table.insert(start_options, "options(nvimcom.autoglbenv = 0)")
     end
+    -- Force debugging while developing plugin option
+    table.insert(start_options, "options(nvimcom.debug_r = TRUE)")
     if config.setwidth and config.setwidth == 2 then
         table.insert(start_options, "options(nvimcom.setwidth = TRUE)")
     else

--- a/lua/r/run.lua
+++ b/lua/r/run.lua
@@ -86,8 +86,6 @@ start_R2 = function()
     else
         table.insert(start_options, "options(nvimcom.autoglbenv = 0)")
     end
-    -- Force debugging while developing plugin option
-    table.insert(start_options, "options(nvimcom.debug_r = TRUE)")
     if config.setwidth and config.setwidth == 2 then
         table.insert(start_options, "options(nvimcom.setwidth = TRUE)")
     else

--- a/nvimcom/R/nvimcom.R
+++ b/nvimcom/R/nvimcom.R
@@ -24,6 +24,7 @@ NvimcomEnv$pkgRdDB <- list()
         options(nvimcom.texerrs = TRUE)
         options(nvimcom.setwidth = TRUE)
         options(nvimcom.autoglbenv = 0)
+        options(nvimcom.debug_r = TRUE)
         options(nvimcom.nvimpager = TRUE)
         options(nvimcom.max_depth = 12)
         options(nvimcom.max_size = 1000000)
@@ -57,6 +58,7 @@ NvimcomEnv$pkgRdDB <- list()
            as.integer(getOption("nvimcom.max_depth")),
            as.integer(getOption("nvimcom.max_size")),
            as.integer(getOption("nvimcom.max_time")),
+           as.integer(getOption("nvimcom.debug_r")),
            NvimcomEnv$info[1],
            NvimcomEnv$info[2],
            PACKAGE = "nvimcom")

--- a/nvimcom/src/nvimcom.c
+++ b/nvimcom/src/nvimcom.c
@@ -1262,7 +1262,7 @@ static void *client_loop_thread(__attribute__((unused)) void *arg)
  * @param rinfo Information on R to be passed to nvim.
  */
 void nvimcom_Start(int *vrb, int *anm, int *swd, int *age, int *imd, int *szl,
-                   int *tml, char **nvv, int *dbg, char **rinfo) {
+                   int *tml, int *dbg, char **nvv, char **rinfo) {
     verbose = *vrb;
     allnames = *anm;
     setwidth = *swd;

--- a/nvimcom/src/nvimcom.c
+++ b/nvimcom/src/nvimcom.c
@@ -1004,27 +1004,23 @@ static void SrcrefInfo(void) {
         send_to_nvim("lua require('r.debug').stop()");
         return;
     }
+
     /* If we have a valid R_Srcref, use it */
     if (R_Srcref && R_Srcref != R_NilValue) {
-        if (TYPEOF(R_Srcref) == VECSXP)
-            R_Srcref = VECTOR_ELT(R_Srcref, 0);
-        SEXP srcfile = getAttrib(R_Srcref, R_SrcfileSymbol);
-        if (TYPEOF(srcfile) == ENVSXP) {
-            SEXP filename = findVar(install("filename"), srcfile);
-            if (isString(filename) && length(filename)) {
-                size_t slen = strlen(CHAR(STRING_ELT(filename, 0)));
-                char *buf = calloc(sizeof(char), (2 * slen + 56));
-                char *buf2 = calloc(sizeof(char), (2 * slen + 56));
-                snprintf(buf, 2 * slen + 1, "%s",
-                         CHAR(STRING_ELT(filename, 0)));
-                nvimcom_squo(buf, buf2, 2 * slen + 32);
-                snprintf(buf, 2 * slen + 55,
-                         "lua require('r.debug').jump('%s', %d)", buf2,
-                         asInteger(R_Srcref));
-                send_to_nvim(buf);
-                free(buf);
-                free(buf2);
-            }
+        SEXP filename = R_GetSrcFilename(R_Srcref);
+        if (isString(filename) && length(filename)) {
+            size_t slen = strlen(CHAR(STRING_ELT(filename, 0)));
+            char *buf = calloc(sizeof(char), (2 * slen + 56));
+            char *buf2 = calloc(sizeof(char), (2 * slen + 56));
+            snprintf(buf, 2 * slen + 1, "%s",
+                    CHAR(STRING_ELT(filename, 0)));
+            nvimcom_squo(buf, buf2, 2 * slen + 32);
+            snprintf(buf, 2 * slen + 55,
+                    "lua require('r.debug').jump('%s', %d)", buf2,
+                    asInteger(R_Srcref));
+            send_to_nvim(buf);
+            free(buf);
+            free(buf2);
         }
     }
 }

--- a/nvimcom/src/nvimcom.c
+++ b/nvimcom/src/nvimcom.c
@@ -1001,7 +1001,7 @@ static void nvimcom_fire(void) {
 static void SrcrefInfo(void) {
     // Adapted from SrcrefPrompt(), at src/main/eval.c
     if (debugging == 0) {
-        send_to_nvim("lua require('r.debug').stop_r_debugging()");
+        send_to_nvim("lua require('r.debug').stop()");
         return;
     }
     /* If we have a valid R_Srcref, use it */
@@ -1013,13 +1013,13 @@ static void SrcrefInfo(void) {
             SEXP filename = findVar(install("filename"), srcfile);
             if (isString(filename) && length(filename)) {
                 size_t slen = strlen(CHAR(STRING_ELT(filename, 0)));
-                char *buf = calloc(sizeof(char), (2 * slen + 32));
-                char *buf2 = calloc(sizeof(char), (2 * slen + 32));
+                char *buf = calloc(sizeof(char), (2 * slen + 56));
+                char *buf2 = calloc(sizeof(char), (2 * slen + 56));
                 snprintf(buf, 2 * slen + 1, "%s",
                          CHAR(STRING_ELT(filename, 0)));
                 nvimcom_squo(buf, buf2, 2 * slen + 32);
-                snprintf(buf, 2 * slen + 31,
-                         "lua require('r.debug').r_debug_jump('%s', %d)", buf2,
+                snprintf(buf, 2 * slen + 55,
+                         "lua require('r.debug').jump('%s', %d)", buf2,
                          asInteger(R_Srcref));
                 send_to_nvim(buf);
                 free(buf);


### PR DESCRIPTION
This fixes the split path functions to match the new `treesitter-r` node syntax.