### PR TITLE
🐛 (brackets.lua): fix incorrect Treesitter query by replacing 'dollar' with 'extract_operator'

### DIFF
--- a/lua/r/format/brackets.lua
+++ b/lua/r/format/brackets.lua
@@ -4,11 +4,11 @@ local parsers = require("nvim-treesitter.parsers")
 
 -- Define the Treesitter query for capturing nodes
 local query = [[
-(dollar
+(extract_operator
     (identifier)
-    (dollar
+    (extract_operator
         (identifier)
-        (dollar
+        (extract_operator
             (identifier)
         )*
     )*


### PR DESCRIPTION
To comply with the new design of `treesitter-r`.