### PR TITLE
✨ Better split path (handle paths and URLs) and let user choose which split function to use

### DIFF
--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -1827,6 +1827,22 @@ used in the current buffer that are not installed as missing. These missing
 packages can be automatically installed using the `<LocalLeader>ip` (install
 packages) key binding.
 
+------------------------------------------------------------------------------
+6.38. Split file paths and URLs                                   *split_path
+
+You can split the path of the current file, directory, or a URL under the
+cursor into its components (e.g., directory, file name, extension) using the
+`<LocalLeader>sp` key binding. If the target string is detected as a file or a
+path, it will be split using the `/` character (e.g., Unix-like paths) and
+processed using a specified function designed to handle paths safely. By
+default, the `split_path_fun` is set to `file.path`. To use a different
+function, you can configure the `split_path_fun` value in your settings.
+Current available functions are:
+>lua
+  path_split_fun   = { "here::here", "here", "file.path", "fs::path", "path" }
+
+If the target string is detected as a URL, it will be split using the '/' character.
+will be handled using the `paste0()` function.
 
 ==============================================================================
 7. Custom key bindings                                   *R.nvim-key-bindings*

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -67,6 +67,7 @@ local config = {
     open_pdf            = "open and focus",
     paragraph_begin     = true,
     parenblock          = true,
+    path_split_fun      = "file.path",
     pdfviewer           = "",
     quarto_preview_args = "",
     quarto_render_args  = "",
@@ -193,7 +194,8 @@ local apply_user_opts = function()
         open_html        = { "no", "open", "open and focus" },
         open_pdf         = { "no", "open", "open and focus" },
         setwd            = { "no", "file", "nvim" },
-        pipe_version     = { "native", "magrittr" }
+        pipe_version     = { "native", "magrittr" },
+        path_split_fun   = { "here::here", "here", "file.path", "fs::path", "path" },
     }
     -- stylua: ignore end
 

--- a/lua/r/maps.lua
+++ b/lua/r/maps.lua
@@ -18,10 +18,9 @@ local map_desc = {
     RViewDFv            = { m = "", k = "", c = "Edit",     d = "View the data.frame or matrix under cursor in a vertically split window" },
     RViewDFa            = { m = "", k = "", c = "Edit",     d = "View the head of a data.frame or matrix under cursor in a split window" },
     RShowEx             = { m = "", k = "", c = "Edit",     d = "Extract the Examples section and paste it in a split window" },
-    RSeparatePathPaste  = { m = "", k = "", c = "Edit",     d = "Split the path of the file under the cursor and paste it using the paste() prefix function" },
+    RSeparatePath       = { m = "", k = "", c = "Edit",     d = "Split the file path or the url under the cursor" },
     RFormatNumbers      = { m = "", k = "", c = "Edit",     d = "Add an 'L' suffix after numbers to explicitly indicate them as integers." },
     RFormatSubsetting   = { m = "", k = "", c = "Edit",     d = "Replace all the `$` subsetting operators with `[[` in the current buffer." },
-    RSeparatePathHere   = { m = "", k = "", c = "Edit",     d = "Split the path of the file under the cursor and open it using the here() prefix function" },
     RNextRChunk         = { m = "", k = "", c = "Navigate", d = "Go to the next chunk of R code" },
     RGoToTeX            = { m = "", k = "", c = "Navigate", d = "Go the corresponding line in the generated LaTeX document" },
     RPreviousRChunk     = { m = "", k = "", c = "Navigate", d = "Go to the previous chunk of R code" },
@@ -215,8 +214,7 @@ local edit = function()
     end
     create_maps("nvi", "RSetwd", "rd", "<Cmd>lua require('r.run').setwd()")
 
-    create_maps("nvi", "RSeparatePathPaste",    "sp", "<Cmd>lua require('r.path').separate('paste')")
-    create_maps("nvi", "RSeparatePathHere",    "sh", "<Cmd>lua require('r.path').separate('here')")
+    create_maps("nvi", "RSeparatePath",    "sp", "<Cmd>lua require('r.path').separate()")
 
     -- Format functions
     create_maps("nvi", "RFormatNumbers",    "cn", "<Cmd>lua require('r.format.numbers').formatnum()")

--- a/lua/r/path.lua
+++ b/lua/r/path.lua
@@ -1,26 +1,103 @@
 local M = {}
 
-local unquote_and_split_file_path = function(file_path)
-    local quote = file_path:match("^[\"']")
-    if quote then
-        file_path = file_path:sub(2, -2) -- Remove surrounding quotes
+-- Define the different types of paths.
+local PathType = {
+    FILE = "file",
+    URL = "url",
+    UNKNOWN = "unknown",
+}
+
+--- Checks if the function name is one of the path functions.
+---@param function_name string The name of the function to check.
+---@return boolean Returns true if the function name is a path function, otherwise false.
+local function is_path_fun(function_name)
+    local path_split_fun =
+        { "here::here", "here", "file.path", "fs::path", "path", "paste0", "paste" }
+
+    for _, value in ipairs(path_split_fun) do
+        if function_name:match(value) then return true end
     end
-
-    -- Split the path into components
-    local components = {}
-    for component in file_path:gmatch("[^/]+") do
-        table.insert(components, component)
-    end
-
-    -- If path starts with a /, add it to the first component
-    if file_path:sub(1, 1) == "/" then components[1] = "/" .. components[1] end
-
-    -- Join the components with the detected quote
-    local result = table.concat(components, quote .. ", " .. quote)
-
-    return result
+    return false
 end
 
+--- Checks if the given path is a valid file path.
+---@param path string The path to check.
+---@return boolean Returns true if the path is a valid file path, otherwise false.
+local function is_valid_file_path(path)
+    local file_pattern = "^.*/[^/]+%.[^/]+$"
+    return path:match(file_pattern) ~= nil
+end
+
+--- Checks if the given path is a valid directory path.
+---@param path string The path to check.
+---@return boolean Returns true if the path is a valid directory path, otherwise false.
+local function is_valid_directory_path(path)
+    local dir_pattern = "^.*/[^/]*[/]?$"
+    return path:match(dir_pattern) ~= nil
+end
+
+--- Determines the type of path (file or url) based on the input string.
+---@param str string The path string to be analyzed.
+---@return string A string representing the type of path, which can be "file", "url", or "unknown".
+local function get_path_type(str)
+    -- Remove surrounding quotes if they exist
+    local cleaned_str = str:match("^%s*['\"](.-)['\"]%s*$")
+        or str:match("^%s*[(](.-)[)]%s*$")
+        or str:match("^%s*(.-)%s*$")
+
+    -- Check if the path starts with "whatever://"
+    if cleaned_str:match("^[%w+-.]+://") then return PathType.URL end
+
+    -- Check if the path starts with "/" or contains "/"
+    if is_valid_file_path(cleaned_str) or is_valid_directory_path(cleaned_str) then
+        return PathType.FILE
+    end
+
+    return PathType.UNKNOWN
+end
+
+--- Splits a path string into its components.
+---@param file_path string The path string to be split.
+---@return string A string representing the formatted path components, separated by commas.
+local function split_path(file_path)
+    local quote = file_path:match("^[\"']")
+    if quote then file_path = file_path:sub(2, -2) end
+
+    local components = {}
+    local url_pattern = "^[a-zA-Z][a-zA-Z%d+-.]*://"
+
+    if file_path:match(url_pattern) then
+        local protocol, rest = file_path:match("^(.-://)(.+)")
+        table.insert(components, protocol)
+        local rest_pattern = "([^/]+)(/?)"
+        for component, slash in rest:gmatch(rest_pattern) do
+            if #component > 0 then table.insert(components, component .. slash) end
+        end
+    else
+        local path_start = file_path:match("^/") and "/" or ""
+        local path = path_start .. file_path:match("^/?(.+)")
+        local is_first_component = true
+
+        for component in path:gmatch("[^/]+") do
+            if is_first_component then
+                table.insert(components, path_start .. component)
+                is_first_component = false
+            else
+                table.insert(components, component)
+            end
+        end
+    end
+
+    for i, component in ipairs(components) do
+        components[i] = quote .. component .. quote
+    end
+
+    return table.concat(components, ", ")
+end
+
+--- Replaces the text of a node with a formatted path string.
+---@param node table The Treesitter node to be updated.
+---@param formatted_path string The formatted path string to replace the node's text with.
 local function replace_path(node, formatted_path)
     local bufnr = vim.api.nvim_get_current_buf()
     local start_row, start_col, end_row, end_col = node:range()
@@ -35,51 +112,50 @@ local function replace_path(node, formatted_path)
     )
 end
 
-M.separate = function(prefix)
-    local path
+--- Processes and formats the path found in the current Treesitter node.
+-- This function updates the path within the Treesitter node based on its type and context.
+M.separate = function()
     local node = vim.treesitter.get_node()
+    if not node or node:type() ~= "string_content" then return end
 
-    if node and node:type() == "string_content" then
-        local parent_node = node:parent()
-        if parent_node then
-            path = vim.treesitter.get_node_text(parent_node, 0)
-        else
-            return
+    local string_node = node:parent()
+    if not string_node then return end
+
+    local path = vim.treesitter.get_node_text(string_node, 0)
+
+    local path_type = get_path_type(path)
+
+    if path_type == PathType.UNKNOWN then return end
+
+    local parent_node = string_node:parent()
+
+    while parent_node do
+        if parent_node:type() == "call" or parent_node:type() == "binary_operator" then
+            break
         end
-
-        -- Check if the path is a URL or doesn't contain slashes
-        if
-            path:match("https?://")
-            or path:match("ftp://")
-            or path:match("s3://")
-            or not path:match("/")
-        then
-            return
-        end
-
-        -- Traverse up the syntax tree until we find a call_expression node
-        local parent = node:parent()
-        while parent do
-            if parent:type() == "call" then
-                local function_name = vim.treesitter.get_node_text(parent, 0)
-                if function_name:match("paste") or function_name:match("here") then
-                    return
-                end
-            end
-            parent = parent:parent()
-        end
-
-        -- Format the path
-        local formatted_path = unquote_and_split_file_path(path)
-
-        if prefix == "paste" then
-            formatted_path = 'paste("' .. formatted_path .. '", sep = "/")'
-        elseif prefix == "here" then
-            formatted_path = 'here("' .. formatted_path .. '")'
-        end
-
-        replace_path(node:parent(), formatted_path)
+        parent_node = parent_node:parent()
     end
+
+    if not parent_node then return end
+
+    local function_name = vim.treesitter.get_node_text(parent_node:child(), 0)
+
+    -- Do not process if the path is already surrounded by a path function
+    if is_path_fun(function_name) and not (parent_node:type() == "binary_operator") then
+        return
+    end
+
+    local formatted_path = split_path(path)
+
+    if path_type == PathType.URL then
+        formatted_path = "paste0(" .. formatted_path .. ")"
+    else
+        local config = require("r.config").get_config()
+        local split_fun = config.path_split_fun
+        formatted_path = split_fun .. "(" .. formatted_path .. ")"
+    end
+
+    replace_path(string_node, formatted_path)
 end
 
 return M


### PR DESCRIPTION

♻️ (path.lua): refactor path handling and splitting logic for better readability and extensibility
✨ (config.lua): add split_path_fun option to configuration 
♻️ (maps.lua): consolidate path splitting commands into RSeparatePath 
♻️ (path.lua): refactor path handling and splitting logic for clarity and efficiency

If the string is a file path, the user can decide which split function to use:

```lua
    local valid_values = {
        auto_start       = { "no", "on startup", "always" },
        editing_mode     = { "vi", "emacs" },
        nvimpager        = { "no", "tab", "split_h", "split_v", "float" },
        open_html        = { "no", "open", "open and focus" },
        open_pdf         = { "no", "open", "open and focus" },
        setwd            = { "no", "file", "nvim" },
        pipe_version     = { "native", "magrittr" },
        split_path_fun   = { "here::here", "here", "file.path", "fs::path", "path" },
    }
```

If the string is a URL, keep the `/` and use the `paste0()` function.

Demo:

![Peek 2024-07-19 13-23](https://github.com/user-attachments/assets/c30d3a6f-b3bf-43b6-88e6-c393cb5c0350)


