### PR TITLE
Call inform() instead of warn() and print()

### DIFF
--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -112,12 +112,16 @@ local did_real_setup = false
 
 local show_config = function(tbl)
     local opt = tbl.args
+    local out = {}
     if opt and opt:len() > 0 then
         opt = opt:gsub(" .*", "")
-        print(vim.inspect(config[opt]))
+        table.insert(out, { vim.inspect(config[opt]) })
     else
-        print(vim.inspect(config))
+        table.insert(out, { vim.inspect(config) })
     end
+    vim.schedule(function ()
+        vim.api.nvim_echo(out, false, {})
+    end)
 end
 
 local set_editing_mode = function()
@@ -915,7 +919,7 @@ M.check_health = function()
     if vim.fn.has("nvim-0.9.5") ~= 1 then warn("R.nvim requires Neovim >= 0.9.5") end
 
     -- Check if treesitter is available
-    local function check_parsers(parser_name, parsers)
+    local function has_parser(parser_name, parsers)
         local path = "parser" .. (config.is_windows and "\\" or "/") .. parser_name .. "."
         for _, v in pairs(parsers) do
             if v:find(path, 1, true) then return true end
@@ -933,12 +937,14 @@ M.check_health = function()
             "parser" .. (config.is_windows and "\\" or "/") .. "*.*",
             true
         )
-        local has_r_parser = check_parsers("r", parsers)
-        local has_markdown_parser = check_parsers("markdown", parsers)
-        local has_rnoweb_parser = check_parsers("rnoweb", parsers)
-        if not has_r_parser or not has_rnoweb_parser or not has_markdown_parser then
+        if
+            not has_parser("r", parsers)
+            or not has_parser("markdown", parsers)
+            or not has_parser("rnoweb", parsers)
+            or not has_parser("yaml", parsers)
+        then
             warn(
-                'R.nvim requires treesitter parsers for "r", "markdown" and "rnoweb". Please, install them.'
+                'R.nvim requires treesitter parsers for "r", "markdown", "rnoweb", and "yaml". Please, install them.'
             )
         end
     end

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -119,9 +119,7 @@ local show_config = function(tbl)
     else
         table.insert(out, { vim.inspect(config) })
     end
-    vim.schedule(function ()
-        vim.api.nvim_echo(out, false, {})
-    end)
+    vim.schedule(function() vim.api.nvim_echo(out, false, {}) end)
 end
 
 local set_editing_mode = function()

--- a/lua/r/init.lua
+++ b/lua/r/init.lua
@@ -12,7 +12,13 @@ end
 ---@param msg string
 M.inform = function(msg)
     vim.schedule(
-        function() vim.notify(msg, vim.log.levels.INFO, { title = "R.nvim" }) end
+        function()
+            vim.notify(
+                msg,
+                vim.log.levels.INFO,
+                { title = "R.nvim", hide_from_history = true }
+            )
+        end
     )
 end
 

--- a/lua/r/packages.lua
+++ b/lua/r/packages.lua
@@ -1,3 +1,5 @@
+local warn = require("r").warn
+
 local M = {}
 local S = require("r.send")
 local inform = require("r").inform
@@ -93,7 +95,7 @@ M.install_missing_packages = function(bufnr)
         if input == "y" then
             S.cmd(rcmd) -- Replace `S.cmd(rcmd)` with your command
         else
-            print("\nNot installing packages")
+            warn("Not installing packages")
         end
     end)
 end

--- a/lua/r/rmd.lua
+++ b/lua/r/rmd.lua
@@ -1,4 +1,4 @@
-local warn = require("r").warn
+local inform = require("r").inform
 local config = require("r.config").get_config()
 local send = require("r.send")
 local get_lang = require("r.utils").get_lang
@@ -80,7 +80,7 @@ M.send_R_chunk = function(m)
     local lang = get_lang()
     if lang ~= "r" then
         if lang ~= "python" then
-            warn("Not inside an R code chunk.")
+            inform("Not inside an R code chunk.")
         else
             send_py_chunk(m)
         end
@@ -109,7 +109,7 @@ local go_to_previous = function()
     local i = vim.fn.search("^[ \t]*```[ ]*{\\(r\\|python\\)", "bnW") -- Search again for chunk start
     if i == 0 then
         vim.api.nvim_win_set_cursor(0, { curline, 0 })
-        warn("There is no previous R code chunk to go.")
+        inform("There is no previous R code chunk to go.")
         return false
     end
     vim.api.nvim_win_set_cursor(0, { i + 1, 0 }) -- position cursor inside the chunk
@@ -131,7 +131,7 @@ end
 local go_to_next = function()
     local i = vim.fn.search("^[ \t]*```[ ]*{\\(r\\|python\\)", "nW") -- Search for the next chunk start
     if i == 0 then
-        warn("There is no next R code chunk to go.")
+        inform("There is no next R code chunk to go.")
         return false
     end
     vim.api.nvim_win_set_cursor(0, { i + 1, 0 }) -- position cursor inside the next chunk

--- a/lua/r/rnw.lua
+++ b/lua/r/rnw.lua
@@ -1,4 +1,5 @@
 local warn = require("r").warn
+local inform = require("r").inform
 local send = require("r.send")
 local utils = require("r.utils")
 local get_lang = require("r.utils").get_lang
@@ -180,7 +181,7 @@ local go_to_previous = function()
     local i = vim.fn.search("^<<.*$", "bnW")
     if i == 0 then
         vim.api.nvim_win_set_cursor(0, { curline, 0 })
-        warn("There is no previous R code chunk to go.")
+        inform("There is no previous R code chunk to go.")
         return false
     end
     vim.api.nvim_win_set_cursor(0, { i + 1, 0 })
@@ -201,7 +202,7 @@ end
 local go_to_next = function()
     local i = vim.fn.search("^<<.*$", "nW")
     if i == 0 then
-        warn("There is no next R code chunk to go.")
+        inform("There is no next R code chunk to go.")
         return false
     end
     vim.api.nvim_win_set_cursor(0, { i + 1, 0 })

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -1,5 +1,6 @@
 local config = require("r.config").get_config()
 local warn = require("r").warn
+local inform = require("r").inform
 local utils = require("r.utils")
 local get_lang = require("r.utils").get_lang
 local edit = require("r.edit")
@@ -426,7 +427,7 @@ end
 ---@param m boolean True if should move to the next line.
 M.marked_block = function(m)
     if get_lang() ~= "r" then
-        warn("Not in R code.")
+        inform("Not in R code.")
         return
     end
 
@@ -452,7 +453,7 @@ M.marked_block = function(m)
     end
 
     if lineA == 1 and lineB == last_line then
-        warn("The file has no mark!")
+        inform("The file has no mark!")
         return
     end
 
@@ -480,7 +481,7 @@ M.selection = function(m)
         or vim.o.filetype == "quarto"
     then
         if lang ~= "r" and lang ~= "python" then
-            warn("Not inside R or Python code chunk.")
+            inform("Not inside R or Python code chunk.")
             return
         end
     end
@@ -574,13 +575,13 @@ M.line = function(m, lnum)
             return
         end
         if lang ~= "r" then
-            warn("Not inside R or Python code chunk.")
+            inform("Not inside R or Python code chunk.")
             return
         end
     end
 
     if vim.bo.filetype == "rhelp" and lang ~= "r" then
-        warn("Not inside an R section.")
+        inform("Not inside an R section.")
         return
     end
 

--- a/lua/r/server.lua
+++ b/lua/r/server.lua
@@ -454,12 +454,12 @@ end
 
 -- Callback function
 M.echo_rns_info = function(info)
+    local lines = vim.split(info, "\020")
+    local tbl = {}
+    for _, v in pairs(lines) do
+        table.insert(tbl, { v .. "\n" })
+    end
     vim.schedule(function()
-        local lines = vim.split(info, "\020")
-        local tbl = {}
-        for _, v in pairs(lines) do
-            table.insert(tbl, { v .. "\n" })
-        end
         vim.api.nvim_echo(tbl, false, {})
     end)
 end

--- a/lua/r/server.lua
+++ b/lua/r/server.lua
@@ -459,9 +459,7 @@ M.echo_rns_info = function(info)
     for _, v in pairs(lines) do
         table.insert(tbl, { v .. "\n" })
     end
-    vim.schedule(function()
-        vim.api.nvim_echo(tbl, false, {})
-    end)
+    vim.schedule(function() vim.api.nvim_echo(tbl, false, {}) end)
 end
 
 return M

--- a/lua/r/utils.lua
+++ b/lua/r/utils.lua
@@ -141,7 +141,6 @@ end
 
 local get_fw_info_X = function()
     local config = require("r.config").get_config()
-    local warn = require("r").warn
     local obj = M.system({ "xprop", "-root" }, { text = true }):wait()
     if obj.code ~= 0 then
         warn("Failed to run `xprop -root`")

--- a/lua/r/utils.lua
+++ b/lua/r/utils.lua
@@ -1,3 +1,5 @@
+local warn = require("r").warn
+
 local M = {}
 
 --- Get language at current cursor position of rhelp buffer
@@ -128,7 +130,7 @@ function M.ensure_directory_exists(dir_path)
     -- Check if pcall caught an error
     if not status then
         -- Log the error
-        print("Error creating directory: " .. err)
+        warn("Error creating directory: " .. err)
         -- return false to indicate failure
         return false
     end


### PR DESCRIPTION
- Call either `inform()` or `warn()` instead of `print()` to print messages.
- Call `inform()` instead of `warn()` when the user doesn't need to fix anything.
- Call `nvim_echo()` instead of `print()` in `RConfigShow`.