### PR TITLE
Prevent crash when trying to use changing subsetting function in non-R files

### DIFF
--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -1797,7 +1797,7 @@ option:
 
 
 ------------------------------------------------------------------------------
-6.36. lintr code formatters                                *convert_range_int*
+6.36. Convert numbers to explicit integers                 *convert_range_int*
 
 The `lintr` package (https://lintr.r-lib.org/https://lintr.r-lib.org/)
 provides a way to check R code for common style issues. This section describes
@@ -1812,14 +1812,22 @@ configuration:
 >lua
   convert_range_int = true
 
-`R.nvim` also also convert the subsetting operator `$` to `[[`. For example,
-`x$a` will be converted to `x[["a"]]` and `x$a$b$c$d` will be converted to
-`x[["a"]][["b"]][["c"]][["d"]]`. The default key binding for this is
-`<LocalLeader>cs` (change subsetting). 
+------------------------------------------------------------------------------
+6.36. Convert extraction operators                  *convert_extract_operator*
 
+There are two types of subsetting expressions in R: `$` and `[.` `R.nvim`
+allows to convert the subsetting operators `[` and `$` to `[[`.
+
+   1. First case, when using the `$` operator: `df$var -> df[["var"]]`.
+   2. Second case, when using the `[` operator: `vec[1] -> vec[[1]]`.
+   3. It supports multiple chained subsetting and nested expressions:
+         `df$var[1] -> df[["var"]][[1]]
+
+The default key binding for this functionally is `<LocalLeader>cs` (change
+subsetting).
 
 ------------------------------------------------------------------------------
-6.37. Installing missing R packages in the current buffer    *install_missing*
+6.38. Installing missing R packages in the current buffer    *install_missing*
 
 If the `lintr` package is installed and properly configured
 (https://github.com/R-nvim/R.nvim/wiki/lintr), it will mark any R packages

--- a/lua/r/format/brackets.lua
+++ b/lua/r/format/brackets.lua
@@ -1,3 +1,9 @@
+-- There are two types of subsetting expressions in R: $ and [.
+-- These functions are used to replace the subsetting expressions in R.
+-- First case, when using the $ operator: df$var -> df[["var"]]
+-- Second case, when using the [ operator: vec[1] -> vec[[1]]
+-- It supports multiple subsetting and nested expressions: df$var[1] -> df[["var"]][[1]]
+
 local M = {}
 
 local parsers = require("nvim-treesitter.parsers")
@@ -12,14 +18,20 @@ local query = [[
             (identifier)
         )*
     )*
-) @expression
+) @dollar_operator
+
+(subset
+    (identifier)*
+    (arguments
+      (argument
+        (_) )) @single_bracket)
 ]]
 
 --- Build a replacement string for a given node by traversing its child nodes
 ---@param node userdata: The Treesitter node to traverse
 ---@param bufnr number: The buffer number
 ---@return string: The constructed replacement string
-local function build_replacement(node, bufnr)
+local function build_extract_oprator_replacement(node, bufnr)
     local identifiers = {}
 
     -- Function to recursively collect identifier text
@@ -64,17 +76,32 @@ M.formatsubsetting = function(bufnr)
     -- Parse the query
     local query_obj = vim.treesitter.query.parse(lang, query)
 
-    for _, node, _ in query_obj:iter_captures(root, bufnr, 0, -1) do
-        local replacement = build_replacement(node, bufnr)
-        local range = { node:range() }
-        vim.api.nvim_buf_set_text(
-            bufnr,
-            range[1],
-            range[2],
-            range[3],
-            range[4],
-            { replacement }
-        )
+    for id, node, _ in query_obj:iter_captures(root, bufnr, 0, -1) do
+        local replacement
+
+        if query_obj.captures[id] == "dollar_operator" then
+            replacement = build_extract_oprator_replacement(node, bufnr)
+        elseif query_obj.captures[id] == "single_bracket" then
+            local value_node = node:named_child(0) -- Assuming the first child is the value
+
+            if not value_node then return end
+
+            local value = vim.treesitter.get_node_text(value_node, bufnr)
+            replacement = string.format("[[%s]]", value)
+        end
+
+        -- Replace the node with the constructed replacement
+        if replacement then
+            local range = { node:range() }
+            vim.api.nvim_buf_set_text(
+                bufnr,
+                range[1],
+                range[2],
+                range[3],
+                range[4],
+                { replacement }
+            )
+        end
     end
 end
 

--- a/lua/r/format/brackets.lua
+++ b/lua/r/format/brackets.lua
@@ -4,6 +4,7 @@
 -- Second case, when using the [ operator: vec[1] -> vec[[1]]
 -- It supports multiple subsetting and nested expressions: df$var[1] -> df[["var"]][[1]]
 
+local warn = require("r").warn
 local M = {}
 
 local parsers = require("nvim-treesitter.parsers")
@@ -65,6 +66,12 @@ end
 ---@param bufnr number: (optional) The buffer number to operate on; defaults to the current buffer if not provided
 M.formatsubsetting = function(bufnr)
     bufnr = bufnr or vim.api.nvim_get_current_buf()
+
+    if vim.bo[bufnr].filetype ~= "r" then
+        warn("This function is only available for R files.")
+        return
+    end
+
     local lang = parsers.get_buf_lang(bufnr)
 
     if not lang then return end

--- a/lua/r/format/numbers.lua
+++ b/lua/r/format/numbers.lua
@@ -1,4 +1,6 @@
 local config = require("r.config").get_config()
+
+local warn = require("r").warn
 local M = {}
 
 -- We check if treesitter is available in the check_parsers() function of the
@@ -29,6 +31,12 @@ end
 
 M.formatnum = function(bufnr)
     bufnr = bufnr or vim.api.nvim_get_current_buf()
+
+    if vim.bo[bufnr].filetype ~= "r" then
+        warn("This function is only available for R files.")
+        return
+    end
+
     local lang = parsers.get_buf_lang(bufnr)
 
     if not lang then return end


### PR DESCRIPTION
Due to the absence of Tree-sitter grammar for `.rmd` and `.qmd` files, attempting to use nodes results in a crash. This PR adds a warning to inform the user that the functionality is unavailable outside R files.