### PR TITLE
Fix issues with source()

### DIFF
--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -587,18 +587,7 @@ on your system.
 
 
 ------------------------------------------------------------------------------
-5.3. R's source() issues
-
-The R's `source()` function of the base package prints an extra new line
-between commands if the option `echo = TRUE`, and error and warning messages
-are printed only after the entire code is sourced. This makes it more
-difficult to find errors in the code sent to R. Details:
-
-   https://stat.ethz.ch/pipermail/r-devel/2012-December/065352.html
-
-
-------------------------------------------------------------------------------
-5.4. Wrong message that "R is busy" (Windows only)
+5.3. Wrong message that "R is busy" (Windows only)
 
 On Windows, when code is sent from Neovim to R Console, the nvimcom library
 sets the value of the internal variable `r_is_busy` to 1. The value is set
@@ -613,7 +602,7 @@ as expected again after any valid code is executed in the R Console.
 
 
 ------------------------------------------------------------------------------
-5.5. Error if there is no package installed (on Windows only)
+5.4. Error if there is no package installed (on Windows only)
 
 On Windows, Neovim may fail to recognize that a directory is not writable, and
 this is required by R.nvim to detect if it is necessary to create the
@@ -625,7 +614,7 @@ command before using R.nvim.
 
 
 ------------------------------------------------------------------------------
-5.6. ~/.Rprofile should not output anything (Windows only)
+5.5. ~/.Rprofile should not output anything (Windows only)
 
 The compilation of `nvimcom` during R startup will fail on Windows if your
 `~/.Rprofile` outputs anything. Example of how to replicate the bug:
@@ -634,7 +623,7 @@ The compilation of `nvimcom` during R startup will fail on Windows if your
 <
 
 ------------------------------------------------------------------------------
-5.7 You can't put `syntax enable` in your `init.vim` (OS X only)
+5.6 You can't put `syntax enable` in your `init.vim` (OS X only)
 
 It seems that if you put the command `syntax enable` in your `init.vim` on OS
 X, file type plugins are immediately sourced. Consequently, all R.nvim
@@ -646,7 +635,7 @@ details, please, access:
 
 
 ------------------------------------------------------------------------------
-5.8 R code block not recognized within HTML tags
+5.7 R code block not recognized within HTML tags
 
 An R code block in a Markdown document is not recognized when within an HTML
 tag unless there is an extra empty line between the tag and the beginning of
@@ -673,7 +662,7 @@ until an empty line is found.
 
 
 ------------------------------------------------------------------------------
-5.9 Completion issue with new lines in list names
+5.8 Completion issue with new lines in list names
 
 New lines in list names (which includes column names in data frames and
 matrixes) are replaced with blank spaces in the data used by `cmp-r` and the

--- a/nvimcom/DESCRIPTION
+++ b/nvimcom/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nvimcom
-Version: 0.9.46
-Date: 2024-08-13
+Version: 0.9.47
+Date: 2024-08-25
 Title: Intermediate the Communication Between R and Neovim
 Author: Jakson Aquino
 Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>

--- a/nvimcom/R/misc.R
+++ b/nvimcom/R/misc.R
@@ -125,12 +125,8 @@ nvim_viewobj <- function(oname, fenc = "", nrows = NULL, howto = "tabnew", R_df_
 #' @param print.eval See base::source.
 #' @param spaced See base::source.
 Rnvim.source <- function(..., print.eval = TRUE, spaced = FALSE) {
-    if (with(R.Version(), paste(major, minor, sep = ".")) >= "3.4.0") {
-        base::source(getOption("nvimcom.source.path"), ...,
-                     print.eval = print.eval, spaced = spaced)
-    } else {
-        base::source(getOption("nvimcom.source.path"), ..., print.eval = print.eval)
-    }
+    base::source(getOption("nvimcom.source.path"), ...,
+        print.eval = print.eval, spaced = spaced)
 }
 
 #' Call base::source.
@@ -163,13 +159,13 @@ Rnvim.function <- function(..., local = parent.frame()) Rnvim.source(..., local 
 #' @param local See base::source.
 Rnvim.chunk <- function(..., local = parent.frame()) Rnvim.source(..., local = local)
 
-#' Creates a temporary copy of an R file, source it, and, finally, delete it.
+#' Source a temporary copy of an R file and, finally, delete it.
 #' This function is sent to R Console when the user press `\aa`, `\ae`, or `\ao`.
 #' @param ... Further arguments passed to base::source.
 #' @param local See base::source.
-source.and.clean <- function(f, ...) {
+source.and.clean <- function(f, print.eval = TRUE, ...) {
     on.exit(unlink(f))
-    base::source(f, ...)
+    base::source(f, print.eval = print.eval, ...)
 }
 
 #' Format R code.

--- a/nvimcom/R/misc.R
+++ b/nvimcom/R/misc.R
@@ -163,9 +163,9 @@ Rnvim.chunk <- function(..., local = parent.frame()) Rnvim.source(..., local = l
 #' This function is sent to R Console when the user press `\aa`, `\ae`, or `\ao`.
 #' @param ... Further arguments passed to base::source.
 #' @param local See base::source.
-source.and.clean <- function(f, print.eval = TRUE, ...) {
+source.and.clean <- function(f, print.eval = TRUE, spaced = FALSE, ...) {
     on.exit(unlink(f))
-    base::source(f, print.eval = print.eval, ...)
+    base::source(f, print.eval = print.eval, spaced = spaced, ...)
 }
 
 #' Format R code.


### PR DESCRIPTION
- Set print.eval=TRUE when sourcing the whole file (close #204).
- Remove support for R < 3.4.0.