### PR TITLE
fix(config.lua): correct R detection on Windows

### DIFF
--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -631,7 +631,7 @@ local windows_config = function()
             return rip
         end
 
-        local run_cmd = { "reg.exe", "QUERY", "HKCU\\SOFTWARE\\R-core\\R", "/s" }
+        local run_cmd = { "reg.exe", "QUERY", "HKLM\\SOFTWARE\\R-core\\R", "/s" }
         local rip = get_rip(run_cmd)
         if #rip == 0 then
             -- Normally, 32 bit applications access only 32 bit registry and...
@@ -661,11 +661,11 @@ local windows_config = function()
         rinstallpath = rinstallpath:gsub("%s*$", "")
         local hasR32 = vim.fn.isdirectory(rinstallpath .. "\\bin\\i386")
         local hasR64 = vim.fn.isdirectory(rinstallpath .. "\\bin\\x64")
-        if hasR32 == 1 and not hasR64 then isi386 = true end
-        if hasR64 == 1 and not hasR32 then isi386 = false end
+        if hasR32 == 1 and hasR64 == 0 then isi386 = true end
+        if hasR64 == 1 and hasR32 == 0 then isi386 = false end
         if hasR32 == 1 and isi386 then
             vim.env.PATH = rinstallpath .. "\\bin\\i386;" .. vim.env.PATH
-        elseif hasR64 and isi386 == 0 then
+        elseif hasR64 == 1 and not isi386 then
             vim.env.PATH = rinstallpath .. "\\bin\\x64;" .. vim.env.PATH
         else
             vim.env.PATH = rinstallpath .. "\\bin;" .. vim.env.PATH

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -631,27 +631,32 @@ local windows_config = function()
             return rip
         end
 
-        local run_cmd = { "reg.exe", "QUERY", "HKLM\\SOFTWARE\\R-core\\R", "/s" }
-        local rip = get_rip(run_cmd)
-        if #rip == 0 then
-            -- Normally, 32 bit applications access only 32 bit registry and...
-            -- We have to try again if the user has installed R only in the other architecture.
-            if vim.fn.has("win64") then
-                table.insert(run_cmd, "/reg:64")
-            else
-                table.insert(run_cmd, "/reg:32")
-            end
+        -- Check both HKCU and HKLM. See #223
+        local reg_roots = { "HKCU", "HKLM" }
+        local rip = {}
+        for i = 1, #reg_roots do
+            local run_cmd = { "reg.exe", "QUERY", reg_roots[i] .. "\\SOFTWARE\\R-core\\R", "/s" }
             rip = get_rip(run_cmd)
-        end
+            if #rip == 0 then
+                -- Normally, 32 bit applications access only 32 bit registry and...
+                -- We have to try again if the user has installed R only in the other architecture.
+                if vim.fn.has("win64") then
+                    table.insert(run_cmd, "/reg:64")
+                else
+                    table.insert(run_cmd, "/reg:32")
+                end
+                rip = get_rip(run_cmd)
+            end
 
-        if #rip == 0 then
-            warn(
-                "Could not find R path in Windows Registry. "
-                    .. "If you have already installed R, please, set the value of 'R_path'."
-            )
-            wtime = (uv.hrtime() - wtime) / 1000000000
-            require("r.edit").add_to_debug_info("windows setup", wtime, "Time")
-            return
+            if i == #reg_roots and #rip == 0 then
+                warn(
+                    "Could not find R path in Windows Registry. "
+                        .. "If you have already installed R, please, set the value of 'R_path'."
+                )
+                wtime = (uv.hrtime() - wtime) / 1000000000
+                require("r.edit").add_to_debug_info("windows setup", wtime, "Time")
+                return
+            end
         end
 
         local rinstallpath = nil


### PR DESCRIPTION
### Pull request overview

- Fixes #222 
- Correct the registry query: The root of the Registry entry for R is `HKEY_LOCAL_MACHINE` but not `HKEY_CURRENT_USER.` `HKLM` is also used in Nvim-R. See https://github.com/jalvesaq/Nvim-R/blob/b7cdc9bcd6879465023e20b4a3ae16968edda776/R/windows.vim#L33
- Fix the logic for setting R installation path:
   -  `vim.fn.isdirectory` returns `0` or `1`, but not lua `true` or `false`.
   - `isi386` is a boolean and should not directly compare with `0`