### PR TITLE
feat(R.nvim): add roxygen2 support

### DIFF
--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -1926,6 +1926,14 @@ insinde the function passed to `hook.on_filetype` as in the examples below
 
 
 ==============================================================================
+8. roxygen2 support                                          *R.nvim-roxygen2*
+
+R.nvim has supports to insert roxygen2 skeletons in R scripts. To insert a new
+roxygen2 block, you can use the `<LocalLeader>ir` (insert roxygen) key binding
+while the cursor is in the line above the function definition. If a block of
+roxygen2 is already present, no modification will be made.
+
+==============================================================================
 8. History                                                    *R.nvim-history*
 
 See: https://www.vim.org/scripts/script.php?script_id=2628

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -636,7 +636,8 @@ local windows_config = function()
         local rip = {}
         for i = 1, #reg_roots do
             if #rip == 0 then
-                local run_cmd = { "reg.exe", "QUERY", reg_roots[i] .. "\\SOFTWARE\\R-core\\R", "/s" }
+                local run_cmd =
+                    { "reg.exe", "QUERY", reg_roots[i] .. "\\SOFTWARE\\R-core\\R", "/s" }
                 rip = get_rip(run_cmd)
 
                 if #rip == 0 then
@@ -655,7 +656,11 @@ local windows_config = function()
                                 .. "If you have already installed R, please, set the value of 'R_path'."
                         )
                         wtime = (uv.hrtime() - wtime) / 1000000000
-                        require("r.edit").add_to_debug_info("windows setup", wtime, "Time")
+                        require("r.edit").add_to_debug_info(
+                            "windows setup",
+                            wtime,
+                            "Time"
+                        )
                         return
                     end
                 end
@@ -812,6 +817,12 @@ local create_user_commands = function()
         nargs = "?",
         complete = function() return config_keys end,
     })
+
+    vim.api.nvim_create_user_command(
+        "Roxygenize",
+        function() require("r.roxygen").insert_roxygen(vim.api.nvim_get_current_buf()) end,
+        {}
+    )
 end
 
 local global_setup = function()

--- a/lua/r/maps.lua
+++ b/lua/r/maps.lua
@@ -19,8 +19,9 @@ local map_desc = {
     RViewDFa            = { m = "", k = "", c = "Edit",     d = "View the head of a data.frame or matrix under cursor in a split window" },
     RShowEx             = { m = "", k = "", c = "Edit",     d = "Extract the Examples section and paste it in a split window" },
     RSeparatePath       = { m = "", k = "", c = "Edit",     d = "Split the file path or the url under the cursor" },
-    RFormatNumbers      = { m = "", k = "", c = "Edit",     d = "Add an 'L' suffix after numbers to explicitly indicate them as integers." },
-    RFormatSubsetting   = { m = "", k = "", c = "Edit",     d = "Replace all the `$` subsetting operators with `[[` in the current buffer." },
+    RFormatNumbers      = { m = "", k = "", c = "Edit",     d = "Add an 'L' suffix after numbers to explicitly indicate them as integers" },
+    RFormatSubsetting   = { m = "", k = "", c = "Edit",     d = "Replace all the `$` subsetting operators with `[[` in the current buffer" },
+    RInsertRoxygen      = { m = "", k = "", c = "Edit",     d = "Insert roxygen skeleton above the current function definition" },
     RNextRChunk         = { m = "", k = "", c = "Navigate", d = "Go to the next chunk of R code" },
     RGoToTeX            = { m = "", k = "", c = "Navigate", d = "Go the corresponding line in the generated LaTeX document" },
     RPreviousRChunk     = { m = "", k = "", c = "Navigate", d = "Go to the previous chunk of R code" },
@@ -219,6 +220,7 @@ local edit = function()
     -- Format functions
     create_maps("nvi", "RFormatNumbers",    "cn", "<Cmd>lua require('r.format.numbers').formatnum()")
     create_maps("nvi", "RFormatSubsetting",    "cs", "<Cmd>lua require('r.format.brackets').formatsubsetting()")
+    create_maps("nvi", "RInsertRoxygen",    "ir", "<Cmd>lua require('r.roxygen').insert_roxygen()")
 end
 
 local send = function(file_type)

--- a/lua/r/maps.lua
+++ b/lua/r/maps.lua
@@ -21,7 +21,6 @@ local map_desc = {
     RSeparatePath       = { m = "", k = "", c = "Edit",     d = "Split the file path or the url under the cursor" },
     RFormatNumbers      = { m = "", k = "", c = "Edit",     d = "Add an 'L' suffix after numbers to explicitly indicate them as integers" },
     RFormatSubsetting   = { m = "", k = "", c = "Edit",     d = "Replace all the `$` subsetting operators with `[[` in the current buffer" },
-    RInsertRoxygen      = { m = "", k = "", c = "Edit",     d = "Insert roxygen skeleton above the current function definition" },
     RNextRChunk         = { m = "", k = "", c = "Navigate", d = "Go to the next chunk of R code" },
     RGoToTeX            = { m = "", k = "", c = "Navigate", d = "Go the corresponding line in the generated LaTeX document" },
     RPreviousRChunk     = { m = "", k = "", c = "Navigate", d = "Go to the previous chunk of R code" },
@@ -220,7 +219,6 @@ local edit = function()
     -- Format functions
     create_maps("nvi", "RFormatNumbers",    "cn", "<Cmd>lua require('r.format.numbers').formatnum()")
     create_maps("nvi", "RFormatSubsetting",    "cs", "<Cmd>lua require('r.format.brackets').formatsubsetting()")
-    create_maps("nvi", "RInsertRoxygen",    "ir", "<Cmd>lua require('r.roxygen').insert_roxygen()")
 end
 
 local send = function(file_type)

--- a/lua/r/roxygen.lua
+++ b/lua/r/roxygen.lua
@@ -55,7 +55,7 @@ M.insert_roxygen = function(bufnr)
         "#'",
     }
 
-    for id, function_node in query_obj:iter_captures(root, bufnr) do
+    for _, function_node in query_obj:iter_captures(root, bufnr) do
         local start_row, _, end_row, _ = function_node:range()
 
         -- The cursor is within the range of a function definition

--- a/lua/r/roxygen.lua
+++ b/lua/r/roxygen.lua
@@ -1,0 +1,96 @@
+local warn = require("r").warn
+local M = {}
+
+local parsers = require("nvim-treesitter.parsers")
+local api = vim.api
+local treesitter = vim.treesitter
+
+--- Checks if there is a roxygen comment above the given line.
+---@param start_line number: The line number to start checking from.
+---@return boolean: True if a roxygen comment is found, false otherwise.
+local function has_roxygen(start_line)
+    local lines_above = api.nvim_buf_get_lines(0, 0, start_line, false)
+
+    for i = #lines_above, 1, -1 do
+        local line = lines_above[i]
+        if not line:match("^%s*$") then return line:match("^%s*#'%s*") ~= nil end
+    end
+
+    return false
+end
+
+--- Inserts a roxygen comment template above the function at the current cursor position.
+---@param bufnr number: The buffer number where the function is located. If nil, uses the current buffer.
+M.insert_roxygen = function(bufnr)
+    bufnr = bufnr or api.nvim_get_current_buf()
+
+    if vim.bo[bufnr].filetype ~= "r" then
+        warn("This function is only available for R files.")
+        return
+    end
+
+    local lang = parsers.get_buf_lang(bufnr)
+    if not lang then
+        warn("Could not determine the language of the buffer.")
+        return
+    end
+
+    local parser = parsers.get_parser(bufnr)
+    if not parser then
+        warn("No parser found for the current buffer.")
+        return
+    end
+
+    local query = [[
+        (function_definition) @function
+    ]]
+    local query_obj = treesitter.query.parse(lang, query)
+    local root = parser:parse()[1]:root()
+
+    local cursor_pos = api.nvim_win_get_cursor(0)
+    local cursor_line = cursor_pos[1] - 1
+
+    local roxygen_template = {
+        "#' Title",
+        "#'",
+    }
+
+    for id, function_node in query_obj:iter_captures(root, bufnr) do
+        local start_row, _, end_row, _ = function_node:range()
+
+        -- The cursor is within the range of a function definition
+        if cursor_line >= start_row and cursor_line <= end_row then
+            if has_roxygen(start_row) then
+                warn("Roxygen comment already exists for this function.")
+                return
+            end
+
+            local parameters = function_node:child(1)
+            if not parameters then return end
+
+            for parameter in parameters:iter_children() do
+                if parameter:type() == "parameter" then
+                    local name_node = parameter:field("name")
+                    if name_node then
+                        local name_value = treesitter.get_node_text(name_node[1], bufnr)
+                        table.insert(
+                            roxygen_template,
+                            string.format("#' @param %s", name_value)
+                        )
+                    end
+                end
+            end
+
+            table.insert(roxygen_template, "#'")
+            table.insert(roxygen_template, "#' @return")
+            table.insert(roxygen_template, "#' @export")
+
+            api.nvim_buf_set_lines(bufnr, start_row, start_row, false, roxygen_template)
+            return
+        end
+    end
+
+    warn("No function found at the current cursor position.")
+end
+
+return M


### PR DESCRIPTION
This PR introduces the ability to add a roxygen2 documentation skeleton above the current function when the cursor is positioned within it. The default key mapping for this feature is `<localleader>ir`. If you have suggestions for a more suitable keymap, I'm open to feedback.

feat(R.nvim): add roxygen2 support for inserting documentation skeletons
docs(R.nvim): update documentation to include roxygen2 support
fix(maps.lua): correct descriptions for RFormatNumbers and RFormatSubsetting

Demo:

![Peek 2024-08-28 13-55](https://github.com/user-attachments/assets/dbf90d0f-00c3-4c4f-80b3-f94f14730940)
