### PR TITLE
auto_start = 1 is not a valid value

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ More complex configuration (for `R.nvim` only):
                 -- If using fish shell, you could put in your config.fish:
                 -- alias r "R_AUTO_START=true nvim"
                 if vim.env.R_AUTO_START == "true" then
-                    opts.auto_start = 1
+                    opts.auto_start = "on startup"
                     opts.objbr_auto_start = true
                 end
                 require("r").setup(opts)


### PR DESCRIPTION
replaced invalid `auto_start = 1` with `auto_start = "on startup"` in the example configuration