### PR TITLE
feat(R.nvim): add option to register treesitter parsers for quarto and rmd files

### DIFF
--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -704,6 +704,8 @@ command:
 |config_tmux|         Don't use a specially built Tmux config file
 |rconsole_height|     Number of lines of R Console
 |rconsole_width|      Number of columns of R Console
+|register_treesitter| Should R.nvim register treesitter parsers for quarto and
+rmd files. Default is true.
 |min_editor_width|    Minimum number of columns of editor after R start
 |applescript|         Use osascript in macOS to run R.app
 |RStudio_cmd|         Run RStudio instead of R.

--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -704,8 +704,7 @@ command:
 |config_tmux|         Don't use a specially built Tmux config file
 |rconsole_height|     Number of lines of R Console
 |rconsole_width|      Number of columns of R Console
-|register_treesitter| Should R.nvim register treesitter parsers for quarto and
-rmd files. Default is true.
+|register_treesitter| Register treesitter parsers for quarto and rmd files
 |min_editor_width|    Minimum number of columns of editor after R start
 |applescript|         Use osascript in macOS to run R.app
 |RStudio_cmd|         Run RStudio instead of R.
@@ -1354,7 +1353,7 @@ simple as the number `1`.
 
 
 ------------------------------------------------------------------------------
-6.16. Special R functions                                        *listmethods*
+6.17. Special R functions                                        *listmethods*
                                                                  *specialplot*
 
 The R function `args()` lists the arguments of a function, but not the
@@ -1836,8 +1835,9 @@ configuration:
 >lua
   convert_range_int = true
 
+
 ------------------------------------------------------------------------------
-6.36. Convert extraction operators                  *convert_extract_operator*
+6.37. Convert extraction operators                  *convert_extract_operator*
 
 There are two types of subsetting expressions in R: `$` and `[.` `R.nvim`
 allows to convert the subsetting operators `[` and `$` to `[[`.
@@ -1850,8 +1850,9 @@ allows to convert the subsetting operators `[` and `$` to `[[`.
 The default key binding for this functionally is `<LocalLeader>cs` (change
 subsetting).
 
+
 ------------------------------------------------------------------------------
-6.38. Installing missing R packages in the current buffer    *install_missing*
+6.39. Installing missing R packages in the current buffer    *install_missing*
 
 If the `lintr` package is installed and properly configured
 (https://github.com/R-nvim/R.nvim/wiki/lintr), it will mark any R packages
@@ -1859,8 +1860,9 @@ used in the current buffer that are not installed as missing. These missing
 packages can be automatically installed using the `<LocalLeader>ip` (install
 packages) key binding.
 
+
 ------------------------------------------------------------------------------
-6.38. Split file paths and URLs                                   *split_path
+6.40. Split file paths and URLs                                   *split_path
 
 You can split the path of the current file, directory, or a URL under the
 cursor into its components (e.g., directory, file name, extension) using the
@@ -1875,6 +1877,17 @@ Current available functions are:
 
 If the target string is detected as a URL, it will be split using the '/' character.
 will be handled using the `paste0()` function.
+
+
+------------------------------------------------------------------------------
+6.41. Tree-sitter parser for Quarto and RMarkdown        *register_treesitter*
+
+R.nvim registers the Markdown parser to both Quarto and RMarkdown documents.
+This will change in the future if dedicated parsers are written for them.
+You can disable this feature in your R.nvim config:
+>lua
+  register_treesitter = false
+
 
 ==============================================================================
 7. Custom key bindings                                   *R.nvim-key-bindings*

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -73,6 +73,7 @@ local config = {
     quarto_render_args  = "",
     rconsole_height     = 15,
     rconsole_width      = 80,
+    register_treesitter = true,
     remote_compldir     = "",
     rm_knit_cache       = false,
     rmarkdown_args      = "",
@@ -908,6 +909,10 @@ M.real_setup = function()
         vim.schedule(function() config.hook.on_filetype() end)
     end
     require("r.rproj").apply_settings(config)
+
+    if config.register_treesitter then
+        vim.treesitter.language.register("markdown", { "quarto", "rmd" })
+    end
 end
 
 --- Return the table with the final configure variables: the default values


### PR DESCRIPTION
nvim-treesitter recently stoped to register rmd and quarto as filetypes. This is a problem because the syntax highlighting is not working anymore. This PR adds a new option `register_treesitter` to let the user decide if they want to register the filetypes or not. By default, the filetypes are registered.

See the commit here: https://github.com/nvim-treesitter/nvim-treesitter/commit/da61d31a3d51f38a78a739392aabf79e7b2f523f
