### PR TITLE
expand ~ in server.lua

### DIFF
--- a/lua/r/server.lua
+++ b/lua/r/server.lua
@@ -22,7 +22,7 @@ local mk_R_dir = function(libd)
             { prompt = '"' .. libd .. '" is not writable. Create it now? [y/n] ' },
             function(input)
                 if input and input:find("y") then
-                    local dw = vim.fn.mkdir(libd, "p")
+                    local dw = vim.fn.mkdir(vim.fn.expand(libd), "p")
                     if dw == 1 then
                         -- Try again
                         M.check_nvimcom_version()


### PR DESCRIPTION
Installing this plugin on my new PC who had just installed R, I fell into repeated prompt for `mk`ing`dir`.
'Cause it made a dir `./~/R/...`. Fixed by adding `expand`.