### PR TITLE
set params in global env & introduce set_params option, fixes #285

### DIFF
--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -747,6 +747,7 @@ command:
 |open_html|           Open HTML after processing Rmd or Quarto
 |insert_mode_cmds|    Allow R commands in insert mode
 |rmhidden|            Remove hidden objects from R workspace
+|set_params|          Control setting `params` in `.GlobalEnv` (`"no" ` to disable).
 |wait|                Time to wait for nvimcom loading
 |wait_reply|          Time to wait for R reply
 |setwd|               Directory where to start R

--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -747,7 +747,7 @@ command:
 |open_html|           Open HTML after processing Rmd or Quarto
 |insert_mode_cmds|    Allow R commands in insert mode
 |rmhidden|            Remove hidden objects from R workspace
-|set_params|          Control setting `params` in `.GlobalEnv` (`"no" ` to disable).
+|set_params|          Control setting `params` in `.GlobalEnv`
 |wait|                Time to wait for nvimcom loading
 |wait_reply|          Time to wait for R reply
 |setwd|               Directory where to start R
@@ -2067,6 +2067,19 @@ This will change in the future if dedicated parsers are written for them.
 You can disable this feature in your R.nvim config:
 >lua
   register_treesitter = false
+
+
+------------------------------------------------------------------------------
+6.42. Set `params` based on the YAML header                       *set_params*
+
+Set `params` based on the YAML header for R Markdown and Quarto documents.
+Defaults to `"yes"`. Valid values:
+
+   `"no"`:          Don't create the object `params` in the `.GlobalEnv`.
+   `"no_override"`: Create the object `params` only if it doesn't exist yet.
+   `"yes"`:         Create and override the object `params` whenever the
+                  corresponding YAML field changes.
+
 
 ==============================================================================
 7. Public Lua API                                             *public-lua-api*

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -384,6 +384,10 @@ local hooks = require("r.hooks")
 ---Time to wait before loading the {nvimcom} package after starting R; defaults
 ---to `60` seconds. See |wait| or `:help wait` for more information.
 ---@field wait? integer
+---
+---Set `params` based on the YAML header for R Markdown and
+---Quarto documents. Defaults to `"yes"`.
+---@field set_params? string
 
 ---@alias RprojField '"pipe_version"'
 
@@ -512,6 +516,7 @@ local config = {
         open_fun = "",  -- Use an R function to open the data.frame directly (no conversion to CSV needed)
     },
     wait                = 60,
+    set_params          = "yes",
 }
 
 -- stylua: ignore end
@@ -577,6 +582,7 @@ local apply_user_opts = function()
         "open_pdf",
         "open_html",
         "setwd",
+        "set_params",
     }) do
         if user_opts[v] then user_opts[v] = string.lower(user_opts[v]) end
     end
@@ -600,6 +606,7 @@ local apply_user_opts = function()
         setwd            = { "no", "file", "nvim" },
         pipe_version     = { "native", "magrittr" },
         path_split_fun   = { "here::here", "here", "file.path", "fs::path", "path" },
+        set_params       = { "no", "yes"},
     }
     -- stylua: ignore end
 

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -387,7 +387,7 @@ local hooks = require("r.hooks")
 ---
 ---Set `params` based on the YAML header for R Markdown and
 ---Quarto documents. Defaults to `"yes"`.
----@field set_params? string
+---@field set_params? '"no"' | '"no_override"' | '"yes"'
 
 ---@alias RprojField '"pipe_version"'
 
@@ -606,7 +606,7 @@ local apply_user_opts = function()
         setwd            = { "no", "file", "nvim" },
         pipe_version     = { "native", "magrittr" },
         path_split_fun   = { "here::here", "here", "file.path", "fs::path", "path" },
-        set_params       = { "no", "yes"},
+        set_params       = { "no", "no_override", "yes"},
     }
     -- stylua: ignore end
 

--- a/lua/r/edit.lua
+++ b/lua/r/edit.lua
@@ -96,10 +96,7 @@ M.buf_enter = function()
     then
         rscript_buf = vim.api.nvim_get_current_buf()
     end
-    if
-        config.set_params ~= "no"
-        and (vim.o.filetype == "rmd" or vim.o.filetype == "quarto")
-    then
+    if vim.o.filetype == "rmd" or vim.o.filetype == "quarto" then
         require("r.rmd").update_params()
     end
 end

--- a/lua/r/edit.lua
+++ b/lua/r/edit.lua
@@ -96,7 +96,10 @@ M.buf_enter = function()
     then
         rscript_buf = vim.api.nvim_get_current_buf()
     end
-    if vim.o.filetype == "rmd" or vim.o.filetype == "quarto" then
+    if
+        config.set_params ~= "no"
+        and (vim.o.filetype == "rmd" or vim.o.filetype == "quarto")
+    then
         require("r.rmd").update_params()
     end
 end

--- a/lua/r/rmd.lua
+++ b/lua/r/rmd.lua
@@ -152,6 +152,7 @@ local has_params = false
 --- Get the params variable from the YAML metadata and send it to nvimcom which
 --- will create the params list in the .GlobalEnv.
 M.update_params = function()
+    if config.set_params == "no" then return end
     if not vim.g.R_Nvim_status then return end
     if vim.g.R_Nvim_status < 7 then return end
 
@@ -225,7 +226,9 @@ M.setup = function()
     -- Record setup time for debugging
     rmdtime = (uv.hrtime() - rmdtime) / 1000000000
     require("r.edit").add_to_debug_info("rmd setup", rmdtime, "Time")
-    vim.cmd("autocmd BufWritePost <buffer> lua require('r.rmd').update_params()")
+    if config.set_params != "no" then
+        vim.cmd("autocmd BufWritePost <buffer> lua require('r.rmd').update_params()")
+    end
 end
 
 --- Compiles the current R Markdown document into a specified output format.

--- a/lua/r/rmd.lua
+++ b/lua/r/rmd.lua
@@ -226,9 +226,7 @@ M.setup = function()
     -- Record setup time for debugging
     rmdtime = (uv.hrtime() - rmdtime) / 1000000000
     require("r.edit").add_to_debug_info("rmd setup", rmdtime, "Time")
-    if config.set_params ~= "no" then
-        vim.cmd("autocmd BufWritePost <buffer> lua require('r.rmd').update_params()")
-    end
+    vim.cmd("autocmd BufWritePost <buffer> lua require('r.rmd').update_params()")
 end
 
 --- Compiles the current R Markdown document into a specified output format.

--- a/lua/r/rmd.lua
+++ b/lua/r/rmd.lua
@@ -226,7 +226,7 @@ M.setup = function()
     -- Record setup time for debugging
     rmdtime = (uv.hrtime() - rmdtime) / 1000000000
     require("r.edit").add_to_debug_info("rmd setup", rmdtime, "Time")
-    if config.set_params != "no" then
+    if config.set_params ~= "no" then
         vim.cmd("autocmd BufWritePost <buffer> lua require('r.rmd').update_params()")
     end
 end

--- a/lua/r/rmd.lua
+++ b/lua/r/rmd.lua
@@ -152,9 +152,9 @@ local has_params = false
 --- Get the params variable from the YAML metadata and send it to nvimcom which
 --- will create the params list in the .GlobalEnv.
 M.update_params = function()
-    if config.set_params == "no" then return end
     if not vim.g.R_Nvim_status then return end
     if vim.g.R_Nvim_status < 7 then return end
+    if config.set_params == "no" then return end
 
     local lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
     if lines[1] ~= "---" then return end

--- a/lua/r/run.lua
+++ b/lua/r/run.lua
@@ -79,6 +79,11 @@ start_R2 = function()
     else
         table.insert(start_options, "options(nvimcom.texerrs = FALSE)")
     end
+    if config.set_params == "yes" then
+        table.insert(start_options, "options(nvimcom.preserve_params = FALSE)")
+    else
+        table.insert(start_options, "options(nvimcom.preserve_params = TRUE)")
+    end
 
     local has_cmp_r, _ = pcall(require, "cmp_r")
     if has_cmp_r then

--- a/lua/r/run.lua
+++ b/lua/r/run.lua
@@ -325,7 +325,10 @@ M.set_nvimcom_info = function(nvimcomversion, rpid, wid, r_info)
     vim.g.R_Nvim_status = 7
     hooks.run(config, "after_R_start")
     send.set_send_cmd_fun()
-    if vim.o.filetype == "quarto" or vim.o.filetype == "rmd" then
+    if
+        config.set_params ~= "no"
+        and (vim.o.filetype == "quarto" or vim.o.filetype == "rmd")
+    then
         require("r.rmd").update_params()
     end
 end

--- a/lua/r/run.lua
+++ b/lua/r/run.lua
@@ -69,6 +69,10 @@ start_R2 = function()
         start_options,
         "options(nvimcom.max_time = " .. tostring(config.compl_data.max_time) .. ")"
     )
+    table.insert(
+        start_options,
+        'options(nvimcom.set_params = "' .. config.set_params .. '")'
+    )
     if config.objbr_allnames then
         table.insert(start_options, "options(nvimcom.allnames = TRUE)")
     else
@@ -78,11 +82,6 @@ start_R2 = function()
         table.insert(start_options, "options(nvimcom.texerrs = TRUE)")
     else
         table.insert(start_options, "options(nvimcom.texerrs = FALSE)")
-    end
-    if config.set_params == "yes" then
-        table.insert(start_options, "options(nvimcom.preserve_params = FALSE)")
-    else
-        table.insert(start_options, "options(nvimcom.preserve_params = TRUE)")
     end
 
     local has_cmp_r, _ = pcall(require, "cmp_r")
@@ -330,10 +329,7 @@ M.set_nvimcom_info = function(nvimcomversion, rpid, wid, r_info)
     vim.g.R_Nvim_status = 7
     hooks.run(config, "after_R_start")
     send.set_send_cmd_fun()
-    if
-        config.set_params ~= "no"
-        and (vim.o.filetype == "quarto" or vim.o.filetype == "rmd")
-    then
+    if vim.o.filetype == "quarto" or vim.o.filetype == "rmd" then
         require("r.rmd").update_params()
     end
 end

--- a/nvimcom/DESCRIPTION
+++ b/nvimcom/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nvimcom
-Version: 0.9.58
-Date: 2024-11-28
+Version: 0.9.59
+Date: 2024-12-06
 Title: Intermediate the Communication Between R and Neovim
 Author: Jakson Aquino
 Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>

--- a/nvimcom/R/interlace.R
+++ b/nvimcom/R/interlace.R
@@ -359,7 +359,7 @@ nvim.interlace.rmd <- function(Rmdfile, outform = NULL, rmddir, ...) {
             rm(params, envir = .GlobalEnv)
         }
         res <- rmarkdown::render(Rmdfile, outform, ...)
-        if (exists("old_params", inherits = TRUE)) {
+        if (exists("old_params", inherits = FALSE)) {
             assign(
                 "params",
                 old_params,

--- a/nvimcom/R/interlace.R
+++ b/nvimcom/R/interlace.R
@@ -354,13 +354,18 @@ nvim.interlace.rmd <- function(Rmdfile, outform = NULL, rmddir, ...) {
         if (is.na(mtime2) || (!is.na(mtime1) && mtime2 <= mtime1))
             res <- ""
     } else {
-        if (length(grep("^params$", ls(.GlobalEnv))) == 1) {
-            old_params <- params
+        if (exists("params", envir = .GlobalEnv)) {
+            old_params <- get("params", envir = .GlobalEnv)
             rm(params, envir = .GlobalEnv)
         }
         res <- rmarkdown::render(Rmdfile, outform, ...)
-        if (exists("old_params"))
-            params <<- old_params
+        if (exists("old_params", envir = .GlobalEnv)) {
+            assign(
+                "params",
+                old_params,
+                envir = .GlobalEnv
+            )
+        }
     }
     brwsr <- ""
     if (endsWith(res, ".html")) {

--- a/nvimcom/R/interlace.R
+++ b/nvimcom/R/interlace.R
@@ -359,7 +359,7 @@ nvim.interlace.rmd <- function(Rmdfile, outform = NULL, rmddir, ...) {
             rm(params, envir = .GlobalEnv)
         }
         res <- rmarkdown::render(Rmdfile, outform, ...)
-        if (exists("old_params", envir = .GlobalEnv)) {
+        if (exists("old_params", inherits = TRUE)) {
             assign(
                 "params",
                 old_params,

--- a/nvimcom/R/misc.R
+++ b/nvimcom/R/misc.R
@@ -467,6 +467,7 @@ nvim_complete_args <- function(id, rkeyword, argkey, firstobj = "", lib = NULL, 
 }
 
 update_params <- function(fname) {
+    if config.set_params == "no" then return end
     if (fname == "DeleteOldParams") {
         if (exists("params", envir = .GlobalEnv)) {
             rm(params, envir = .GlobalEnv)

--- a/nvimcom/R/misc.R
+++ b/nvimcom/R/misc.R
@@ -472,6 +472,10 @@ update_params <- function(fname) {
             rm(params, envir = .GlobalEnv)
         }
     } else {
+        if (exists("params", envir = .GlobalEnv) &&
+            getOption("nvimcom.preserve_params"))
+            return(invisible(NULL))
+
         if (!require(knitr, quietly = TRUE))
             stop("Please, install the 'knitr' package.")
         flines <- readLines(fname)

--- a/nvimcom/R/misc.R
+++ b/nvimcom/R/misc.R
@@ -468,14 +468,19 @@ nvim_complete_args <- function(id, rkeyword, argkey, firstobj = "", lib = NULL, 
 
 update_params <- function(fname) {
     if (fname == "DeleteOldParams") {
-        if (length(grep("^params$", ls(.GlobalEnv))) == 1) {
+        if (exists("params", envir = .GlobalEnv)) {
             rm(params, envir = .GlobalEnv)
         }
     } else {
         if (!require(knitr, quietly = TRUE))
             stop("Please, install the 'knitr' package.")
         flines <- readLines(fname)
-        params <<- knitr::knit_params(flines) |> lapply(\(x) x$value)
+        params <- knitr::knit_params(flines)
+        assign(
+            "params",
+            lapply(params, \(x) x$value),
+            envir = .GlobalEnv
+        )
     }
     .C("nvimcom_task", PACKAGE = "nvimcom")
     return(invisible(NULL))

--- a/nvimcom/R/misc.R
+++ b/nvimcom/R/misc.R
@@ -467,15 +467,20 @@ nvim_complete_args <- function(id, rkeyword, argkey, firstobj = "", lib = NULL, 
 }
 
 update_params <- function(fname) {
+    if (
+        getOption("nvimcom.set_params") == "no" ||
+          (
+            getOption("nvimcom.set_params") == "no_override" &&
+                exists("params", envir = .GlobalEnv)
+          )
+    ) {
+      return(invisible(NULL))
+    }
     if (fname == "DeleteOldParams") {
         if (exists("params", envir = .GlobalEnv)) {
             rm(params, envir = .GlobalEnv)
         }
     } else {
-        if (exists("params", envir = .GlobalEnv) &&
-            getOption("nvimcom.preserve_params"))
-            return(invisible(NULL))
-
         if (!require(knitr, quietly = TRUE))
             stop("Please, install the 'knitr' package.")
         flines <- readLines(fname)

--- a/nvimcom/R/misc.R
+++ b/nvimcom/R/misc.R
@@ -467,7 +467,6 @@ nvim_complete_args <- function(id, rkeyword, argkey, firstobj = "", lib = NULL, 
 }
 
 update_params <- function(fname) {
-    if config.set_params == "no" then return end
     if (fname == "DeleteOldParams") {
         if (exists("params", envir = .GlobalEnv)) {
             rm(params, envir = .GlobalEnv)


### PR DESCRIPTION
- More robust handling of environments when updating `params`
- Introduce `set_params` config option; setting `set_params="no"` disables the feature. The reasoning is that modifying global environment is not always desirable, so a user might want to control this behavior. 

I made `set_params` a string, as I can imagine there could be more behaviors. E.g., maybe `set_params="no_override"` is useful, when `R.nvim` will set the variable initially but never override it if it is set already.