### PR TITLE
Fix wrong resolve of argument completion

### DIFF
--- a/nvimcom/DESCRIPTION
+++ b/nvimcom/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nvimcom
-Version: 0.9.59
-Date: 2024-12-06
+Version: 0.9.60
+Date: 2024-12-10
 Title: Intermediate the Communication Between R and Neovim
 Author: Jakson Aquino
 Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>

--- a/nvimcom/src/apps/complete.c
+++ b/nvimcom/src/apps/complete.c
@@ -200,24 +200,30 @@ void resolve_arg_item(char *pkg, char *fnm, char *itm) {
                         while (*s)
                             s++;
                         while (*s != '\n') {
-                            // Look for \0 or ' ' because some arguments share
-                            // the same documentation item. Example: lm()
-                            if (*s == 0 || *s == ' ') {
-                                s++;
-                                if (str_here(s, itm)) {
-                                    s += strlen(itm);
-                                    if (*s == '\005' || *s == ',') {
-                                        while (*s && *s != '\005')
-                                            s++;
+                            if (*s == 0) {
+                                while (*s != '\005') {
+                                    // Look for \0 or ' ' because some arguments share
+                                    // the same documentation item. Example: lm()
+                                    if (*s == 0 || *s == ' ') {
                                         s++;
-                                        char *b =
-                                            calloc(strlen(s) + 2, sizeof(char));
-                                        format(s, b, ' ', '\x14');
-                                        printf("lua %s('%s')\n", resolve_cb, b);
-                                        fflush(stdout);
-                                        free(b);
-                                        return;
+                                        if (str_here(s, itm)) {
+                                            s += strlen(itm);
+                                            if (*s == '\005' || *s == ',') {
+                                                while (*s && *s != '\005')
+                                                    s++;
+                                                s++;
+                                                char *b =
+                                                    calloc(strlen(s) + 2, sizeof(char));
+                                                format(s, b, ' ', '\x14');
+                                                printf("lua %s('%s')\n", resolve_cb, b);
+                                                fflush(stdout);
+                                                free(b);
+                                                return;
+                                            }
+                                        }
+
                                     }
+                                    s++;
                                 }
                             }
                             s++;


### PR DESCRIPTION
If the argument name appears in the description of a previous argument preceded by a empty space and followed by a comma, cmp-r would show the wrong description for the argument. For, example, when resolving the "habillage" argument from the plot.MCA function (FactoMineR package).