### PR TITLE
Minor improvements in R help

### DIFF
--- a/lua/r/rdoc.lua
+++ b/lua/r/rdoc.lua
@@ -14,6 +14,7 @@ M.set_buf_options = function()
     vim.api.nvim_set_option_value("iskeyword", "@,48-57,_,.", { scope = "local" })
     vim.api.nvim_set_option_value("signcolumn", "no", { scope = "local" })
     vim.api.nvim_set_option_value("foldcolumn", "0", { scope = "local" })
+    vim.api.nvim_set_option_value("conceallevel", 2, { scope = "local" })
     if vim.bo.filetype ~= "rmd" then
         vim.api.nvim_set_option_value("filetype", "rmd", { scope = "local" })
     end

--- a/nvimcom/R/bol.R
+++ b/nvimcom/R/bol.R
@@ -367,7 +367,7 @@ get_arg_doc_list <- function(fun, pkg) {
     atbl[, 1] <- gsub("\\\\dots", "...", atbl[, 1])
     args <- apply(atbl, 1,
                   function(x)
-                      paste0(x[1], "\x05`", x[1], "`: ",
+                      paste0(x[1], "\x05`", gsub(", ", "`, `", x[1]), "`: ",
                              .Call("rd2md", x[2], PACKAGE = "nvimcom"), "\x06"))
     line <- nvim.fix.string(paste0(fun, "\x06", paste0(args, collapse = "")))
     cat(line, sep = "", "\n")


### PR DESCRIPTION
- conceallevel=2 in documentation to hide empty space around argument items.
- backtick quotes around each argument item in cmp-r.