### PR TITLE
Display `:RMapsDesc` and `:RConfigShow` in a split buffer instead of as an `nvim_echo()` statement

### DIFF
--- a/lua/r/commands.lua
+++ b/lua/r/commands.lua
@@ -3,74 +3,74 @@ local config = require("r.config").get_config()
 local M = {}
 
 local function show_config(tbl)
-	local opt = tbl.args
-	local out = {}
-	if opt and opt:len() > 0 then
-		opt = opt:gsub(" .*", "")
-		table.insert(out, { vim.inspect(config[opt]) })
-	else
-		table.insert(out, { vim.inspect(config) })
-	end
+    local opt = tbl.args
+    local out = {}
+    if opt and opt:len() > 0 then
+        opt = opt:gsub(" .*", "")
+        table.insert(out, { vim.inspect(config[opt]) })
+    else
+        table.insert(out, { vim.inspect(config) })
+    end
 
-	local out_buf = {} -- separate the out string to a table of strings separated by "\n"
-	for str in string.gmatch(out[1][1], "([^\n]+)") do
-		table.insert(out_buf, str)
-	end
+    local out_buf = {} -- separate the out string to a table of strings separated by "\n"
+    for str in string.gmatch(out[1][1], "([^\n]+)") do
+        table.insert(out_buf, str)
+    end
 
-	local buf = vim.api.nvim_create_buf(false, true) -- no file, scratch buffer
-	vim.api.nvim_buf_set_text(buf, 0, 0, -1, -1, out_buf)
-	vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
-	vim.api.nvim_open_win(buf, true, { style = "minimal", split = "above" })
+    local buf = vim.api.nvim_create_buf(false, true) -- no file, scratch buffer
+    vim.api.nvim_buf_set_text(buf, 0, 0, -1, -1, out_buf)
+    vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
+    vim.api.nvim_open_win(buf, true, { style = "minimal", split = "above" })
 end
 
 local config_keys = {}
 for k, _ in pairs(config) do
-	table.insert(config_keys, tostring(k))
+    table.insert(config_keys, tostring(k))
 end
 
 function M.create_user_commands()
-	vim.api.nvim_create_user_command("RStop", function(_)
-		require("r.run").signal_to_R("SIGINT")
-	end, {})
-	vim.api.nvim_create_user_command("RKill", function(_)
-		require("r.run").signal_to_R("SIGKILL")
-	end, {})
-	vim.api.nvim_create_user_command("RBuildTags", require("r.edit").build_tags, {})
-	vim.api.nvim_create_user_command("RDebugInfo", require("r.edit").show_debug_info, {})
-	vim.api.nvim_create_user_command("RMapsDesc", require("r.maps").show_map_desc, {})
+    vim.api.nvim_create_user_command("RStop", function(_)
+        require("r.run").signal_to_R("SIGINT")
+    end, {})
+    vim.api.nvim_create_user_command("RKill", function(_)
+        require("r.run").signal_to_R("SIGKILL")
+    end, {})
+    vim.api.nvim_create_user_command("RBuildTags", require("r.edit").build_tags, {})
+    vim.api.nvim_create_user_command("RDebugInfo", require("r.edit").show_debug_info, {})
+    vim.api.nvim_create_user_command("RMapsDesc", require("r.maps").show_map_desc, {})
 
-	vim.api.nvim_create_user_command("RSend", function(tbl)
-		require("r.send").cmd(tbl.args)
-	end, { nargs = 1 })
+    vim.api.nvim_create_user_command("RSend", function(tbl)
+        require("r.send").cmd(tbl.args)
+    end, { nargs = 1 })
 
-	vim.api.nvim_create_user_command("RFormat", require("r.run").formart_code, { range = "%" })
+    vim.api.nvim_create_user_command("RFormat", require("r.run").formart_code, { range = "%" })
 
-	vim.api.nvim_create_user_command("RInsert", function(tbl)
-		require("r.run").insert(tbl.args, "here")
-	end, { nargs = 1 })
+    vim.api.nvim_create_user_command("RInsert", function(tbl)
+        require("r.run").insert(tbl.args, "here")
+    end, { nargs = 1 })
 
-	vim.api.nvim_create_user_command("RSourceDir", function(tbl)
-		require("r.run").source_dir(tbl.args)
-	end, { nargs = 1, complete = "dir" })
+    vim.api.nvim_create_user_command("RSourceDir", function(tbl)
+        require("r.run").source_dir(tbl.args)
+    end, { nargs = 1, complete = "dir" })
 
-	vim.api.nvim_create_user_command("RHelp", function(tbl)
-		require("r.doc").ask_R_help(tbl.args)
-	end, {
-		nargs = "?",
-		complete = require("r.server").list_objs,
-	})
+    vim.api.nvim_create_user_command("RHelp", function(tbl)
+        require("r.doc").ask_R_help(tbl.args)
+    end, {
+        nargs = "?",
+        complete = require("r.server").list_objs,
+    })
 
-	vim.api.nvim_create_user_command("RConfigShow", show_config, {
-		nargs = "?",
-		complete = function()
-			return config_keys
-		end,
-	})
+    vim.api.nvim_create_user_command("RConfigShow", show_config, {
+        nargs = "?",
+        complete = function()
+            return config_keys
+        end,
+    })
 
-	vim.api.nvim_create_user_command("Roxygenize", function()
-		require("r.roxygen").insert_roxygen(vim.api.nvim_get_current_buf())
-	end, {})
+    vim.api.nvim_create_user_command("Roxygenize", function()
+        require("r.roxygen").insert_roxygen(vim.api.nvim_get_current_buf())
+    end, {})
 end
 
-show_config(config_keys)
+
 return M

--- a/lua/r/commands.lua
+++ b/lua/r/commands.lua
@@ -3,80 +3,74 @@ local config = require("r.config").get_config()
 local M = {}
 
 local function show_config(tbl)
-    local opt = tbl.args
-    local out = {}
-    if opt and opt:len() > 0 then
-        opt = opt:gsub(" .*", "")
-        table.insert(out, { vim.inspect(config[opt]) })
-    else
-        table.insert(out, { vim.inspect(config) })
-    end
-    vim.schedule(function() vim.api.nvim_echo(out, false, {}) end)
+	local opt = tbl.args
+	local out = {}
+	if opt and opt:len() > 0 then
+		opt = opt:gsub(" .*", "")
+		table.insert(out, { vim.inspect(config[opt]) })
+	else
+		table.insert(out, { vim.inspect(config) })
+	end
+
+	local out_buf = {} -- separate the out string to a table of strings separated by "\n"
+	for str in string.gmatch(out[1][1], "([^\n]+)") do
+		table.insert(out_buf, str)
+	end
+
+	local buf = vim.api.nvim_create_buf(false, true) -- no file, scratch buffer
+	vim.api.nvim_buf_set_text(buf, 0, 0, -1, -1, out_buf)
+	vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
+	vim.api.nvim_open_win(buf, true, { style = "minimal", split = "above" })
 end
 
 local config_keys = {}
 for k, _ in pairs(config) do
-    table.insert(config_keys, tostring(k))
+	table.insert(config_keys, tostring(k))
 end
 
 function M.create_user_commands()
-    vim.api.nvim_create_user_command(
-        "RStop",
-        function(_) require("r.run").signal_to_R("SIGINT") end,
-        {}
-    )
-    vim.api.nvim_create_user_command(
-        "RKill",
-        function(_) require("r.run").signal_to_R("SIGKILL") end,
-        {}
-    )
-    vim.api.nvim_create_user_command("RBuildTags", require("r.edit").build_tags, {})
-    vim.api.nvim_create_user_command("RDebugInfo", require("r.edit").show_debug_info, {})
-    vim.api.nvim_create_user_command("RMapsDesc", require("r.maps").show_map_desc, {})
+	vim.api.nvim_create_user_command("RStop", function(_)
+		require("r.run").signal_to_R("SIGINT")
+	end, {})
+	vim.api.nvim_create_user_command("RKill", function(_)
+		require("r.run").signal_to_R("SIGKILL")
+	end, {})
+	vim.api.nvim_create_user_command("RBuildTags", require("r.edit").build_tags, {})
+	vim.api.nvim_create_user_command("RDebugInfo", require("r.edit").show_debug_info, {})
+	vim.api.nvim_create_user_command("RMapsDesc", require("r.maps").show_map_desc, {})
 
-    vim.api.nvim_create_user_command(
-        "RSend",
-        function(tbl) require("r.send").cmd(tbl.args) end,
-        { nargs = 1 }
-    )
+	vim.api.nvim_create_user_command("RSend", function(tbl)
+		require("r.send").cmd(tbl.args)
+	end, { nargs = 1 })
 
-    vim.api.nvim_create_user_command(
-        "RFormat",
-        require("r.run").formart_code,
-        { range = "%" }
-    )
+	vim.api.nvim_create_user_command("RFormat", require("r.run").formart_code, { range = "%" })
 
-    vim.api.nvim_create_user_command(
-        "RInsert",
-        function(tbl) require("r.run").insert(tbl.args, "here") end,
-        { nargs = 1 }
-    )
+	vim.api.nvim_create_user_command("RInsert", function(tbl)
+		require("r.run").insert(tbl.args, "here")
+	end, { nargs = 1 })
 
-    vim.api.nvim_create_user_command(
-        "RSourceDir",
-        function(tbl) require("r.run").source_dir(tbl.args) end,
-        { nargs = 1, complete = "dir" }
-    )
+	vim.api.nvim_create_user_command("RSourceDir", function(tbl)
+		require("r.run").source_dir(tbl.args)
+	end, { nargs = 1, complete = "dir" })
 
-    vim.api.nvim_create_user_command(
-        "RHelp",
-        function(tbl) require("r.doc").ask_R_help(tbl.args) end,
-        {
-            nargs = "?",
-            complete = require("r.server").list_objs,
-        }
-    )
+	vim.api.nvim_create_user_command("RHelp", function(tbl)
+		require("r.doc").ask_R_help(tbl.args)
+	end, {
+		nargs = "?",
+		complete = require("r.server").list_objs,
+	})
 
-    vim.api.nvim_create_user_command("RConfigShow", show_config, {
-        nargs = "?",
-        complete = function() return config_keys end,
-    })
+	vim.api.nvim_create_user_command("RConfigShow", show_config, {
+		nargs = "?",
+		complete = function()
+			return config_keys
+		end,
+	})
 
-    vim.api.nvim_create_user_command(
-        "Roxygenize",
-        function() require("r.roxygen").insert_roxygen(vim.api.nvim_get_current_buf()) end,
-        {}
-    )
+	vim.api.nvim_create_user_command("Roxygenize", function()
+		require("r.roxygen").insert_roxygen(vim.api.nvim_get_current_buf())
+	end, {})
 end
 
+show_config(config_keys)
 return M

--- a/lua/r/commands.lua
+++ b/lua/r/commands.lua
@@ -29,48 +29,63 @@ for k, _ in pairs(config) do
 end
 
 function M.create_user_commands()
-    vim.api.nvim_create_user_command("RStop", function(_)
-        require("r.run").signal_to_R("SIGINT")
-    end, {})
-    vim.api.nvim_create_user_command("RKill", function(_)
-        require("r.run").signal_to_R("SIGKILL")
-    end, {})
+    vim.api.nvim_create_user_command(
+        "RStop",
+        function(_) require("r.run").signal_to_R("SIGINT") end,
+        {}
+    )
+    vim.api.nvim_create_user_command(
+        "RKill",
+        function(_) require("r.run").signal_to_R("SIGKILL") end,
+        {}
+    )
     vim.api.nvim_create_user_command("RBuildTags", require("r.edit").build_tags, {})
     vim.api.nvim_create_user_command("RDebugInfo", require("r.edit").show_debug_info, {})
     vim.api.nvim_create_user_command("RMapsDesc", require("r.maps").show_map_desc, {})
 
-    vim.api.nvim_create_user_command("RSend", function(tbl)
-        require("r.send").cmd(tbl.args)
-    end, { nargs = 1 })
+    vim.api.nvim_create_user_command(
+        "RSend",
+        function(tbl) require("r.send").cmd(tbl.args) end,
+        { nargs = 1 }
+    )
 
-    vim.api.nvim_create_user_command("RFormat", require("r.run").formart_code, { range = "%" })
+    vim.api.nvim_create_user_command(
+        "RFormat",
+        require("r.run").formart_code,
+        { range = "%" }
+    )
 
-    vim.api.nvim_create_user_command("RInsert", function(tbl)
-        require("r.run").insert(tbl.args, "here")
-    end, { nargs = 1 })
+    vim.api.nvim_create_user_command(
+        "RInsert",
+        function(tbl) require("r.run").insert(tbl.args, "here") end,
+        { nargs = 1 }
+    )
 
-    vim.api.nvim_create_user_command("RSourceDir", function(tbl)
-        require("r.run").source_dir(tbl.args)
-    end, { nargs = 1, complete = "dir" })
+    vim.api.nvim_create_user_command(
+        "RSourceDir",
+        function(tbl) require("r.run").source_dir(tbl.args) end,
+        { nargs = 1, complete = "dir" }
+    )
 
-    vim.api.nvim_create_user_command("RHelp", function(tbl)
-        require("r.doc").ask_R_help(tbl.args)
-    end, {
-        nargs = "?",
-        complete = require("r.server").list_objs,
-    })
+    vim.api.nvim_create_user_command(
+        "RHelp",
+        function(tbl) require("r.doc").ask_R_help(tbl.args) end,
+        {
+            nargs = "?",
+            complete = require("r.server").list_objs,
+        }
+    )
 
     vim.api.nvim_create_user_command("RConfigShow", show_config, {
         nargs = "?",
-        complete = function()
-            return config_keys
-        end,
+        complete = function() return config_keys end,
     })
 
-    vim.api.nvim_create_user_command("Roxygenize", function()
-        require("r.roxygen").insert_roxygen(vim.api.nvim_get_current_buf())
-    end, {})
+    vim.api.nvim_create_user_command(
+        "Roxygenize",
+        function() require("r.roxygen").insert_roxygen(vim.api.nvim_get_current_buf()) end,
+        {}
+    )
 end
-
 
 return M

--- a/lua/r/commands.lua
+++ b/lua/r/commands.lua
@@ -8,18 +8,26 @@ local function show_config(tbl)
     if opt and opt:len() > 0 then
         opt = opt:gsub(" .*", "")
         table.insert(out, { vim.inspect(config[opt]) })
+        vim.api.nvim_echo(out, false, {}) -- if argument is passed, only print it out at the bottom
+        return
     else
         table.insert(out, { vim.inspect(config) })
     end
 
-    local out_buf = {} -- separate the out string to a table of strings separated by "\n"
-    for str in string.gmatch(out[1][1], "([^\n]+)") do
-        table.insert(out_buf, str)
-    end
+    local out_buf = vim.split(out[1][1], "\n") -- separate the out string to a table of strings separated by "\n"
 
     local buf = vim.api.nvim_create_buf(false, true) -- no file, scratch buffer
-    vim.api.nvim_buf_set_text(buf, 0, 0, -1, -1, out_buf)
+    vim.api.nvim_buf_set_lines(buf, 0, 0, false, out_buf)
+
+    for row, line in ipairs(out_buf) do -- add highlighting to keywords
+        local col = line:find("=")
+        if col ~= nil then
+            vim.api.nvim_buf_add_highlight(buf, -1, "Type", row - 1, 0, col - 2)
+        end
+    end
+
     vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
+    vim.api.nvim_buf_set_keymap(buf, "n", "q", "<Cmd>q<CR>", {})
     vim.api.nvim_open_win(buf, true, { style = "minimal", split = "above" })
 end
 

--- a/lua/r/maps.lua
+++ b/lua/r/maps.lua
@@ -329,12 +329,8 @@ M.show_map_desc = function()
     local key_w = 1
     fill_k()
     for k, v in pairs(map_desc) do
-        if #k >= label_w then
-            label_w = #k + 1
-        end
-        if #v.k >= key_w then
-            key_w = #v.k + 1
-        end
+        if #k >= label_w then label_w = #k + 1 end
+        if #v.k >= key_w then key_w = #v.k + 1 end
     end
     local lw = tostring(label_w)
     local kw = tostring(key_w)
@@ -360,7 +356,10 @@ M.show_map_desc = function()
     for _, c in pairs(cat) do
         table.insert(map_key_desc, { c .. "\n", "Title" })
         for _, v in pairs(bycat[c]) do
-            table.insert(map_key_desc, { string.format("  %-0" .. lw .. "s", v[1]), "Identifier" })
+            table.insert(
+                map_key_desc,
+                { string.format("  %-0" .. lw .. "s", v[1]), "Identifier" }
+            )
             table.insert(map_key_desc, { string.format("  %-04s", v[2]), "Type" })
             local keymap = v[3] or " "
             for _, d in pairs(config.disable_cmds) do

--- a/lua/r/maps.lua
+++ b/lua/r/maps.lua
@@ -411,6 +411,7 @@ M.show_map_desc = function()
         end
     end
 
+    vim.api.nvim_buf_set_keymap(buf, "n", "q", "<Cmd>q<CR>", {})
     vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
     vim.api.nvim_open_win(buf, true, { style = "minimal", split = "above" })
 end

--- a/lua/r/maps.lua
+++ b/lua/r/maps.lua
@@ -292,136 +292,128 @@ end
 local M = {}
 
 M.create = function(file_type)
-	control(file_type)
-	if file_type == "rbrowser" then
-		return
-	end
-	send(file_type)
-	if file_type == "rdoc" then
-		return
-	end
-	start()
-	edit()
+    control(file_type)
+    if file_type == "rbrowser" then return end
+    send(file_type)
+    if file_type == "rdoc" then return end
+    start()
+    edit()
 end
 
 local fill_k2 = function(mlist, m)
-	local km
-	local lbl
-	for _, v in pairs(mlist) do
-		if v:find("@<Plug>R") then
-			lbl = v:gsub(".*@<Plug>", "")
-			lbl = lbl:gsub(" .*", "") -- See issue #288
-			km = v:gsub("^" .. m .. "%s*", "")
-			km = km:gsub(" .*", "")
-			if not map_desc[lbl].m:find(m) then
-				map_desc[lbl].m = map_desc[lbl].m .. m
-			end
-			if map_desc[lbl] and map_desc[lbl].k == "" then
-				map_desc[lbl].k = km
-			end
-		end
-	end
+    local km
+    local lbl
+    for _, v in pairs(mlist) do
+        if v:find("@<Plug>R") then
+            lbl = v:gsub(".*@<Plug>", "")
+            lbl = lbl:gsub(" .*", "") -- See issue #288
+            km = v:gsub("^" .. m .. "%s*", "")
+            km = km:gsub(" .*", "")
+            if not map_desc[lbl].m:find(m) then map_desc[lbl].m = map_desc[lbl].m .. m end
+            if map_desc[lbl] and map_desc[lbl].k == "" then map_desc[lbl].k = km end
+        end
+    end
 end
 
 local fill_k = function()
-	local nlist = vim.split(vim.fn.execute("nmap", "silent!") or "", "\n")
-	local vlist = vim.split(vim.fn.execute("vmap", "silent!") or "", "\n")
-	local ilist = vim.split(vim.fn.execute("imap", "silent!") or "", "\n")
-	fill_k2(nlist, "n")
-	fill_k2(vlist, "v")
-	fill_k2(ilist, "i")
+    local nlist = vim.split(vim.fn.execute("nmap", "silent!") or "", "\n")
+    local vlist = vim.split(vim.fn.execute("vmap", "silent!") or "", "\n")
+    local ilist = vim.split(vim.fn.execute("imap", "silent!") or "", "\n")
+    fill_k2(nlist, "n")
+    fill_k2(vlist, "v")
+    fill_k2(ilist, "i")
 end
 
 M.show_map_desc = function()
-	local label_w = 1
-	local key_w = 1
-	fill_k()
-	for k, v in pairs(map_desc) do
-		if #k >= label_w then
-			label_w = #k + 1
-		end
-		if #v.k >= key_w then
-			key_w = #v.k + 1
-		end
-	end
-	local lw = tostring(label_w)
-	local kw = tostring(key_w)
+    local label_w = 1
+    local key_w = 1
+    fill_k()
+    for k, v in pairs(map_desc) do
+        if #k >= label_w then
+            label_w = #k + 1
+        end
+        if #v.k >= key_w then
+            key_w = #v.k + 1
+        end
+    end
+    local lw = tostring(label_w)
+    local kw = tostring(key_w)
 
-	local cat = {
-		"Start",
-		"Edit",
-		"Navigate",
-		"Send",
-		"Command",
-		"Weave",
-		"Object_Browser",
-	}
-	local bycat = {}
-	for _, c in pairs(cat) do
-		bycat[c] = {}
-	end
-	for k, v in pairs(map_desc) do
-		table.insert(bycat[v.c], { k, v.m, v.k, v.d })
-	end
+    local cat = {
+        "Start",
+        "Edit",
+        "Navigate",
+        "Send",
+        "Command",
+        "Weave",
+        "Object_Browser",
+    }
+    local bycat = {}
+    for _, c in pairs(cat) do
+        bycat[c] = {}
+    end
+    for k, v in pairs(map_desc) do
+        table.insert(bycat[v.c], { k, v.m, v.k, v.d })
+    end
 
-	local map_key_desc = {}
-	for _, c in pairs(cat) do
-		table.insert(map_key_desc, { c .. "\n", "Title" })
-		for _, v in pairs(bycat[c]) do
-			table.insert(map_key_desc, { string.format("  %-0" .. lw .. "s", v[1]), "Identifier" })
-			table.insert(map_key_desc, { string.format("  %-04s", v[2]), "Type" })
-			local keymap = v[3] or " "
-			for _, d in pairs(config.disable_cmds) do
-				if d == v[1] then
-					keymap = "disabled"
-					break
-				end
-			end
-			table.insert(map_key_desc, {
-				string.format("%-0" .. kw .. "s", keymap),
-				keymap == "disabled" and "Comment" or "Special",
-			})
-			table.insert(map_key_desc, { v[4] .. "\n" })
-		end
-	end
+    local map_key_desc = {}
+    for _, c in pairs(cat) do
+        table.insert(map_key_desc, { c .. "\n", "Title" })
+        for _, v in pairs(bycat[c]) do
+            table.insert(map_key_desc, { string.format("  %-0" .. lw .. "s", v[1]), "Identifier" })
+            table.insert(map_key_desc, { string.format("  %-04s", v[2]), "Type" })
+            local keymap = v[3] or " "
+            for _, d in pairs(config.disable_cmds) do
+                if d == v[1] then
+                    keymap = "disabled"
+                    break
+                end
+            end
+            table.insert(map_key_desc, {
+                string.format("%-0" .. kw .. "s", keymap),
+                keymap == "disabled" and "Comment" or "Special",
+            })
+            table.insert(map_key_desc, { v[4] .. "\n" })
+        end
+    end
 
-	local buf = vim.api.nvim_create_buf(false, true) -- no file, scratch buffer
-	local row = -1
-	local col_start = {}
-	local col_end = {}
-	local line = ""
-	local hls = {}
-	for _, text_hl in pairs(map_key_desc) do
-		local text = text_hl[1]:gsub("\n", "")
-		line = line .. text
-		local hl = text_hl[2]
-		if hl == "Title" or hl == "Identifier" or row == -1 then -- start new line on "Title" or "Identifier"
-			row = row + 1
-		end
-		if hl == "Title" then -- on "Title" write to buffer
-			vim.api.nvim_buf_set_lines(buf, row, row, false, { line })
-			vim.api.nvim_buf_add_highlight(buf, -1, hl, row, 0, #line)
-			line = ""
-		elseif hl == "Identifier" then
-			col_start = { 0 }
-			col_end = { #text }
-			table.insert(hls, hl)
-		elseif hl then
-			table.insert(col_start, col_end[#col_end])
-			table.insert(col_end, #line)
-			table.insert(hls, hl)
-		else -- hl is nil so it is the description so it's eol so write to buffer with appropriate highlights
-			vim.api.nvim_buf_set_lines(buf, row, row, false, { line })
-			vim.api.nvim_buf_add_highlight(buf, -1, hls[1], row, col_start[1], col_end[1])
-			vim.api.nvim_buf_add_highlight(buf, -1, hls[2], row, col_start[2], col_end[2])
-			vim.api.nvim_buf_add_highlight(buf, -1, hls[3], row, col_start[3], col_end[3])
-			hls = {}
-			line = ""
-		end
-	end
+    local buf = vim.api.nvim_create_buf(false, true) -- no file, scratch buffer
+    local row = -1
+    local col_start = {}
+    local col_end = {}
+    local line = ""
+    local hls = {}
+    for _, text_hl in pairs(map_key_desc) do
+        local text = text_hl[1]:gsub("\n", "")
+        line = line .. text
+        local hl = text_hl[2]
+        if hl == "Title" or hl == "Identifier" or row == -1 then -- start new line on "Title" or "Identifier"
+            row = row + 1
+        end
+        if hl == "Title" then -- on "Title" write to buffer
+            vim.api.nvim_buf_set_lines(buf, row, row, false, { line })
+            vim.api.nvim_buf_add_highlight(buf, -1, hl, row, 0, #line)
+            line = ""
+        elseif hl == "Identifier" then
+            col_start = { 0 }
+            col_end = { #text }
+            table.insert(hls, hl)
+        elseif hl then
+            table.insert(col_start, col_end[#col_end])
+            table.insert(col_end, #line)
+            table.insert(hls, hl)
+        else -- hl is nil so it is the description so it's eol so write to buffer with appropriate highlights
+            vim.api.nvim_buf_set_lines(buf, row, row, false, { line })
+            vim.api.nvim_buf_add_highlight(buf, -1, hls[1], row, col_start[1], col_end[1])
+            vim.api.nvim_buf_add_highlight(buf, -1, hls[2], row, col_start[2], col_end[2])
+            vim.api.nvim_buf_add_highlight(buf, -1, hls[3], row, col_start[3], col_end[3])
+            hls = {}
+            line = ""
+        end
+    end
 
-	vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
-	vim.api.nvim_open_win(buf, true, { style = "minimal", split = "above" })
+    vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
+    vim.api.nvim_open_win(buf, true, { style = "minimal", split = "above" })
 end
 
 return M


### PR DESCRIPTION
This change will make outputs of these two commands display in a separate buffer, which will allow for easier navigation and searching for specific commands, mappings and config options. This will also mimic the behavior of `:h` making it less dizzying.