### PR TITLE
Fix LSP warnings

### DIFF
--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -1354,7 +1354,7 @@ example, if it is called by a custom script), you should set the value of
 Set this option in your config if you want to pass command line arguments to
 R at the startup. The value of this variable must be a `string[]`. Example:
 >lua
-   R_args = {"--no-save", "--quiet"}
+   R_args = { "--no-save", "--quiet" }
 <
 On Linux, there is no default value for |R_args|. On Windows, the default
 value is `{"--sdi"}`, but you may change it to `{"--mdi"}` if you do not like
@@ -1597,13 +1597,13 @@ If `xelatex` is not installed, it will be replaced with `pdflatex` in the
 above command. If `latexmk` is not installed, R.nvim will call either
 `xelatex` or `pdflatex` directly.
 
-You can set the value `latexcmd` to change this behavior. `latexcmd` is a
-list: its first element is the command to be executed and the remaining
-elements are arguments to be passed to the command. Examples:
+To change this behavior, you can set the value `latexcmd` which is a list
+whose first element is the command to be executed and the remaining elements
+are arguments to be passed to the command. Examples:
 >lua
-   latexcmd = {"pdflatex"}
-   latexcmd = {"xelatex"}
-   latexcmd = {"latexmk", "-pdf", '-pdflatex="xelatex %O -synctex=1 %S"'}
+   latexcmd = { "xelatex" }
+   latexcmd = { "pdflatex", "-interaction=nonstopmode", "-synctex=1" }
+   latexcmd = { "latexmk", "-pdf", '-pdflatex="xelatex %O -synctex=1 %S"' }
 <
 The elements of `latexcmd` may contain double quotes (as in the last example
 above), but not single quotes, because R.nvim will use single quotes to
@@ -1836,12 +1836,12 @@ of key bindings labels is shown with the command:
 Below is an example on how to disable the commands that send `setwd()` and
 `dput()` to R Console:
 >lua
-   disable_cmds = {"RSetwd", "RDputObj"}
+   disable_cmds = { "RSetwd", "RDputObj" }
 <
 If you want to disable R.nvim for a specific file type, create the variable
 `R_filetypes` with a list of file types that should be supported. Example:
 >lua
-   vim.g.R_filetypes = {"r", "rmd", "rnoweb", "quarto", "rhelp"}
+   vim.g.R_filetypes = { "r", "rmd", "rnoweb", "quarto", "rhelp" }
 <
 If the variable `R_filetypes` does not exist, all file types from the above
 list will be supported.

--- a/lua/r/browser.lua
+++ b/lua/r/browser.lua
@@ -205,6 +205,7 @@ local function find_parent(child, curline, curpos)
         line = vim.api.nvim_buf_get_lines(0, curline - 1, curline, true)[1]
         line = line:gsub("\t.*", "")
         idx = line:find("#")
+        if idx == nil then return "" end
         if idx < curpos then
             parent = line:sub(idx + 1)
             if line:find("%[#") or line:find("%$#") then

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -5,158 +5,160 @@ local hooks = require("r.hooks")
 
 ---@class RConfigUserOpts
 ---
----Used to set R's `OutDec` option; see `?options` in R; see |OutDec| or
----`:help OutDec` for more information.
+---Used to set R's `OutDec` option; see `?options` in R; do `:help OutDec` for
+---more information.
 ---@field OutDec? string
 ---
----Optionally set R.nvim to use RStudio to run R code; see `|RStudio_cmd|` or
----`:help RStudio_cmd` for more information.
+---Optionally set R.nvim to use RStudio to run R code; do `:help RStudio_cmd`
+---for more information.
 ---@field RStudio_cmd? string
 ---
 ---Optionally override the command used to start R, defaults to `"R"`.
----See |R_app| or `:help R_app` for more information.
+---Do `:help R_app` for more information.
 ---@field R_app? string
 ---
----Additional command line arguments passed to R on startup. See |R_args| or
----`:help R_args` for more information.
+---Additional command line arguments passed to R on startup. Do `:help R_args`
+---for more information.
 ---@field R_args? string[]
 ---
 ---This command will be used to run some background scripts; Defaults to the
----same value as |R_app|. See |R_cmd| or `:help R_cmd` for more information.
+---same value as `R_app`. Do `:help R_cmd` for more information.
 ---@field R_cmd? string
 ---
 ---Optionally set the path to the R executable used by R.nvim. The user's
----`PATH` environmental variable will be used by default. See |R_path| or
----`:help R_path` for more information.
+---`PATH` environmental variable will be used by default. Do `:help R_path`
+---for more information.
 ---@field R_path? string
 ---
----Whether to add additional highlighting to R output; defaultst to `false`.
----See |Rout_more_colors| or `:help Rout_more_colors` for more information.
+---Whether to add additional highlighting to R output; defaults to `false`.
+---Do `:help Rout_more_colors` for more information.
 ---@field Rout_more_colors? boolean
 ---
 ---Whether to use the R.app graphical application on Mac OS X. Defaults
----to `false`. See |applescript| or `:help applescript` for more information.
+---to `false`. Do `:help applescript` for more information.
 ---@field applescript? boolean
 ---
 ---Whether to remember the window layout when quitting R; defaults to `true`.
----See |arrange_windows| or `:help arrange_windows` for more information.
+---Do `:help arrange_windows` for more information.
 ---@field arrange_windows? boolean
 ---
 ---The keymap used to insert `<-`; defaults to `<M-->`, i.e. Alt + M in most
----terminals. See |assignment_keymap| or `:help assignment_keymap` for more
----information.
+---terminals. Do `:help assignment_keymap` for more information.
 ---@field assignment_keymap? string
 ---
 ---The keymap used to insert the pipe operator; defaults to `<localleader>,`.
----See |pipe_keymap| or `:help pipe_keymap` for more information.
+---Do `:help pipe_keymap` for more information.
 ---@field pipe_keymap? string
 ---
----The version of the pipe operator to insert on |pipe_keymap|; defaults to
----`"native"`. See |pipe_version| or `:help pipe_version` for more information.
+---The version of the pipe operator to insert on `pipe_keymap`; defaults to
+---`"native"`. Do `:help pipe_version` for more information.
 ---@field pipe_version? '"native"' | '"|>"' | '"magrittr"' | '"%>%"'
 ---
 ---Whether to force auto-scrolling in the R console; defaults to `true`.
----See |auto_scroll| or `:help auto_scroll` for more information.
+---Do `:help auto_scroll` for more information.
 ---@field auto_scroll? boolean
 ---
 ---Whether to start R automatically when you open an R script; defaults to
----`"no". See |auto_start| or `:help auto_start` for more information.
+---`"no". Do `:help auto_start` for more information.
 ---@field auto_start? '"no"' | '"on startup"' | '"always"'
 ---
 ---Whether closing Neovim should also quit R; defaults to `true` in Neovim's
----built-in terminal emulator and `false` otherwise. See |auto_quit| or
----`:help auto_quit` for more information.
+---built-in terminal emulator and `false` otherwise. Do `:help auto_quit` for
+---more information.
 ---@field auto_quit? boolean
 ---
 ---Controls which lines are sent to the R console on `<LocalLeader>pp`;
----defaults to `false`. See |bracketed_paste| or `:help bracketed_paste` for
----more information.
+---defaults to `false`. Do `:help bracketed_paste` for more information.
 ---@field bracketed_paste? boolean
 ---
 ---Options to control the behaviour of the R console window; defaults to
----`"winfixwidth winfixheight nobuflisted"`. See `|buffer_opts|` or `:help
----buffer_opts` for more information.
+---`"winfixwidth winfixheight nobuflisted"`. See Do `:help buffer_opts` for
+---more information.
 ---@field buffer_opts? string
 ---
 ---Whether to set a keymap to clear the console; defaults to `true` but should
 ---be set to `false` if your version of R supports this feature out-of-the-box.
----See |clear_console| or `:help clear_console` for more information.
+---Do `:help clear_console` for more information.
 ---@field clear_console? boolean
 ---
 ---Set to `true` to add `<C-a><C-k>` to every R command; defaults to `false`.
----See |clear_line| or `:help clear_line` for more information.
+---Do `:help clear_line` for more information.
 ---@field clear_line? boolean
 ---
 ---Whether to close the terminal window when R quits; defaults to `true`.
----see |close_term| or `:help close_term` for more information.
+---Do `:help close_term` for more information.
 ---@field close_term? boolean
 ---
 ---Whether to set a keymap to format all numbers as integers for the current
----buffer; defaults to `false`. See |convert_range_int| or
----`:help convert_range_int` for more informatin.
+---buffer; defaults to `false`. Do `:help convert_range_int` for more
+---information.
 ---@field convert_range_int? boolean
 ---
 ---Optionally you can give a directory where lists used for autocompletion
----will be stored. Defaults to `""`. See |compldir| or `:help compldir` for
----more information.
+---will be stored. Defaults to `""`. Do `:help compldir` for more information.
 ---@field compldir? string
 ---
----Options for fine-grained control of the object browser. See |compl_data| or
----`:help compl_data` for more information.
+---Options for fine-grained control of the object browser. Do `:help compl_data`
+---for more information.
 ---@field compl_data? { max_depth: integer, max_size: integer, max_time: integer }
 ---
 ---Whether to use R.nvim's configuration for Tmux if running R in an external
 ---terminal emulator. Set to `false` if you want to use your own `.tmux.conf`.
----Defaults to `true`. See |config_tmux| or `:help config_tmux` for more
----information.
+---Defaults to `true`. Do `:help config_tmux` for more information.
 ---@field config_tmux? boolean
 ---
 ---Control the program to use when viewing CSV files; defaults to `""`, i.e.
----to open these in a normal Neovim buffer. See |view_df| or `:help view_df`
----for more information.
+---to open these in a normal Neovim buffer. Do `:help view_df` for more
+---information.
 ---@field view_df? { open_app: string, how: string, csv_sep: string, n_lines: integer, save_fun: string, open_fun: string | function }
 ---
 ---A table of R.nvim commands to disable. Defaults to `{ "" }`.
----See |disable_cmds| or `:help disable_cmds` for more information.
+---Do `:help disable_cmds` for more information.
 ---@field disable_cmds? table<integer, string>
 ---
 ---Set to `"vi"` if R is running in vi editing mode; defaults to `""`.
----See `|editing_mode|` or `:help editing_mode` for more information.
+---Do `:help editing_mode` for more information.
 ---@field editing_mode? string
 ---
 ---Whether to use `<Esc>` to leave terminal mode and enter normal mode;
----defaults to `true`. See |esc_term| or `:help esc_term` for more information.
+---defaults to `true`. Do `:help esc_term` for more information.
 ---@field esc_term? boolean
 ---
----Whether to run R in an external terminal emulator rather than Noevim's
----built-in terminal emulator; defaults to `false`. See |external_term| or
----`:help external_term` for more information.
----@field external_term? boolean
+---Whether to run R in an external terminal emulator rather than Neovim's
+---built-in terminal emulator; defaults to `false`. Do `:help external_term`
+---for more information.
+---@field external_term? boolean | string
 ---
----Whether X tools are avaialble; used for window management. By default the
+---Whether X tools are available; used for window management. By default the
 ---availability will be detected from the system, but you can force its use
 ---by setting this value to `true` or `false`.
 ---@field has_X_tools? boolean
 ---
 ---Whether to highlight R output using Neovim. Defaults to `false` if the
----package {colorout} is loaded, or `true` otherwise. See |hl_term| or
----`:help hl_term` for more information.
+---package {colorout} is loaded, or `true` otherwise. Do `:help hl_term` for
+---more information.
 ---@field hl_term? boolean
 ---
----Functions to run on various events. See |hook| or `:help hook` for more
----information.
+---Functions to run on various events. Do `:help hook` for more information.
 ---@field hook? { on_filetype: RHook, after_config: RHook, after_R_start: RHook, after_ob_open: RHook}
 ---
 ---Whether to allow R.nvim commands when in insert mode; defaults to `false`.
----See |insert_mode_cmds| or `:help insert_mode_cmds` for more information.
+---Do `:help insert_mode_cmds` for more information.
 ---@field insert_mode_cmds? boolean
 ---
----Command and arguments to use when producing PDFs. See |latexcmd| or
----`:help latexcmd` for more information.
+---Command and arguments to use when producing PDFs. Do `:help latexcmd` for
+---more information.
 ---@field latexcmd? table<string, string>
 ---
+---Directory where the LaTeX log file is expected to be found. Do
+---`:help latex_build_dir` for more information.
+---@field latex_build_dir? string
+---
+---Arguments do `Sweave()`. Do `:help sweaveargs` for more information.
+---@field sweaveargs? string
+---
 ---Whether to list arguments for methods on `<localleader>ra`; defaults to
----`false`. See |listmethods| or `:help listmethods` for more information.
+---`false`. Do `:help listmethods` for more information.
 ---@field listmethods? boolean
 ---
 ---Optionally supply the path to the directory where the {nvimcom} is
@@ -165,49 +167,47 @@ local hooks = require("r.hooks")
 ---
 ---When sending lines to the console, this is the number of lines at which
 ---R.nvim will instead create and source a temporary file. Defaults to `20`.
----See |max_paste_lines| or `:help max_paste_lines` for more information.
+---Do `:help max_paste_lines` for more information.
 ---@field max_paste_lines? integer
 ---
----Used to control how R.nvim splits the window when intialising the R console;
----defaults to `80`. See |min_editor_width| or `:help min_editor_width` for
----more information.
+---Used to control how R.nvim splits the window when initialising the R console;
+---defaults to `80`. Do `:help min_editor_width` for more information.
 ---@field min_editor_width? integer
 ---
 ---How to set the working directory when starting R; defaults to `"no"` to not
----set the working directory. See |setwd| or `:help setwd` for more
----information.
+---set the working directory. Do `:help setwd` for more information.
 ---@field setwd? '"no"' | '"file"' | '"nvim"'
 ---
 ---How to open R man pages/help documentation; defaults to `"split_h"`.
----See |nvimpager| or `:help nvimpager` for more information.
+---Do `:help nvimpager` for more information.
 ---@field nvimpager? '"split_h"' | '"split_v"' | '"tab"' | '"float"' | '"no"'
 ---
 ---Whether to show hidden objects in the object browser; defaults to `false`.
----See |objbr_allnames| or `:help objbr_allnames` for more information.
+---Do `:help objbr_allnames` for more information.
 ---@field objbr_allnames? boolean
 ---
 ---Whether to start the object browser when R starts; defaults to `false`.
----See |objbr_auto_start| or `:help objbr_auto_start` for more information.
+---Do `:help objbr_auto_start` for more information.
 ---@field objbr_auto_start? boolean
 ---
----Default height for the object browser; defaults to `10`. See |objbr_h| or
----`:help objbr_h` for more information.
+---Default height for the object browser; defaults to `10`. Do `:help objbr_h`
+---for more information.
 ---@field objbr_h? integer
 ---
 ---Whether to expand dataframes in the object browser; defaults to `true`.
----See |objbr_opendf| or `:help objbr_opendf` for more information.
+---Do `:help objbr_opendf` for more information.
 ---@field objbr_opendf? boolean
 ---
 ---Whether to expand lists in the object browser; defaults to `false`.
----See |objbr_openlist| or `:help objbr_openlist` for more information.
+---Do `:help objbr_openlist` for more information.
 ---@field objbr_openlist? boolean
 ---
 ---Where to open the object browser; defaults to `"script,right"`.
----See |objbr_place| or `:help objbr_place` for more information.
+---Do `:help objbr_place` for more information.
 ---@field objbr_place? string
 ---
----Default width for the object browser; defaults to `40`. See |objbr_w| or
----`:help objbr_w` for more information.
+---Default width for the object browser; defaults to `40`. Do `:help objbr_w`
+---for more information.
 ---@field objbr_w? integer
 ---
 ---Keymappings to set for the object browser. Table keys give the keymaps
@@ -216,173 +216,155 @@ local hooks = require("r.hooks")
 ---@field objbr_mappings? table<string, string>
 ---
 ---Optionally a placeholder to use when setting object browser mappings.
----Defaults to `"{object}"`. See |objbr_placeholder| or
----`:help objbr_placeholder` for more information.
+---Defaults to `"{object}"`. Do `:help objbr_placeholder` for more information.
 ---@field objbr_placeholder? string
 ---
 ---Whether to open R examples in a Neovim buffer; defaults to `true`.
----See |open_example| or `:help open_example` for more information.
+---Do `:help open_example` for more information.
 ---@field open_example? boolean
 ---
 ---How to open HTML files after rendering an R Markdown document; defaults to
----`"open and focus"`. See |open_html| or `:help open_html` for more
----information.
+---`"open and focus"`. Do `:help open_html` for more information.
 ---@field open_html? '"open and focus"' | '"open"' | '"no"'
 ---
 ---How to open PDF files after rendering an R Markdown document; defaults to
----`"open and focus"`. See |open_pdf| or `:help open_pdf` for more
----information.
+---`"open and focus"`. Do `:help open_pdf` for more information.
 ---@field open_pdf? '"open and focus"' | '"open"' | '"no"'
 ---
 ---When sending a line, this controls whether preceding lines are also sent if
 ---they're part of the same paragraph. Defaults to `true`.
----See |paragraph_begin| or `:help paragraph_begin` for more information.
+---Do `:help paragraph_begin` for more information.
 ---@field paragraph_begin? boolean
 ---
 ---Whether to send the surrounding paragraph when an individual line is
----sent to the R console; defaults to `true`. See |parenblock| or
----`:help parenblock` for more information.
+---sent to the R console; defaults to `true`. Do `:help parenblock` for more
+---information.
 ---@field parenblock? boolean
 ---
 ---The function to use when splitting a filepath; defaults to `"file.path"`.
----See |path_split_fun| or `:help path_split_fun` for more information.
+---Do `:help path_split_fun` for more information.
 ---@field path_split_fun? string
 ---
 ---The program to use to open PDF files; the default behaviour depends on the
----platform. See |pdfviewer| or `:help pdfviewer` for more information.
+---platform. Do `:help pdfviewer` for more information.
 ---@field pdfviewer? string
 ---
 ---Additional arguments passed to `quarto::quarto_preview()`; defaults to `""`.
----See |quarto_preview_args| or `:help quarto_preview_args` for more
----information.
+---Do `:help quarto_preview_args` for more information.
 ---@field quarto_preview_args? string
 ---
 ---Additional arguments passed to `quarto::quarto_render()`; defaults to `""`.
----See |quarto_render_args| or `:help quarto_render_args` for more
----information.
+---Do `:help quarto_render_args` for more information.
 ---@field quarto_render_args? string
 ---
 ---The default height for the R console; defaults to `15`.
----See |rconsole_height| or `:help rconsole_height` for more information.
+---Do `:help rconsole_height` for more information.
 ---@field rconsole_height? integer
 ---
 ---The default width for the R console; defaults to `80`.
----See |rconsole_width| or `:help rconsole_width` for more information.
+---Do `:help rconsole_width` for more information.
 ---@field rconsole_width? integer
 ---
 ---Whether to register the Markdown parser for Quarto and RMarkdown documents;
----defaults to `true`. See |register_treesitter| or `:help register_treesitter`
----for more information.
+---defaults to `true`. Do `:help register_treesitter` for more information.
 ---@field register_treesitter? boolean
 ---
 ---Options for accessing a remote R session from local Neovim.
----See |remote_compldir| or `:help remote_compldir` for more information.
+---Do `:help remote_compldir` for more information.
 ---@field remote_compldir? string
 ---
---Whether to automatically remove {knitr} cache files; defaults to `false`.
---This field is undocumented, but users can still apply it if they really
---want to.
---@field private rm_knit_cache? boolean
---
+---Whether to automatically remove {knitr} cache files; defaults to `false`.
+---This field is undocumented, but users can still apply it if they really
+---want to.
+---@field rm_knit_cache? boolean
+---
 ---Additional arguments passed to `rmarkdown::render()`; defaults to `""`.
----See |rmarkdown_args| or `:help rmarkdown_args` for more information.
+---Do `:help rmarkdown_args` for more information.
 ---@field rmarkdown_args? string
 ---
 ---The environment in which to render R Markdown documents; defaults to
----`".GlobalEnv"`. See |rmd_environment| or `:help rmd_environment` for more
----information.
+---`".GlobalEnv"`. Do `:help rmd_environment` for more information.
 ---@field rmd_environment? string
 ---
 ---Controls if and how backticks are replaced with code chunk/inline code
----delimiters when writing R Markdown and Quarto files. See |rmdchunk| or
----`:help rmdchunk` for more information.
+---delimiters when writing R Markdown and Quarto files. Do `:help rmdchunk`
+---for more information.
 ---@field rmdchunk? string | integer
 ---
 ---Whether to remove hidden objects from the workspace on `<LocalLeader>rm`;
----defaults to `false`. See |rmhidden| or `:help rmhidden` for more
----information.
+---defaults to `false`. Do `:help rmhidden` for more information.
 ---@field rmhidden? boolean
 ---S
 ---Whether to replace `<` with `<<>>=\n@` when writing Rnoweb files; defaults
----to `true`. See |rnowebchunk| or `:help rnowebchunk` for more information.
+---to `true`. Do `:help rnowebchunk` for more information.
 ---@field rnowebchunk? boolean
 ---
---The directory containing R.nvim's plugin files.
---@field private rnvim_home? string
---
 ---Controls whether the resulting `.Rout` file is not opened in a new tab when
----running `R CMD BATCH`; defaults to `false`. See |routnotab| or
----`:help routnotab` for more information.
+---running `R CMD BATCH`; defaults to `false`. Do `:help routnotab` for more
+---information.
 ---@field routnotab? boolean
 ---
 ---Controls which fields from a `.Rproj` file should influence R.nvim settings.
----Defaults to `{ "pipe_version" }`. See |proj_prioritise| or
----`:help rproj_prioritise` for more information.
+---Defaults to `{ "pipe_version" }`. Do `:help rproj_prioritise` for more
+---information.
 ---@field rproj_prioritise? table<integer, RprojField>
 ---
 ---Whether to save the position of the R console on quit; defaults to `true`.
----See |save_win_pos| or `:help save_win_pos` for more information.
+---Do `:help save_win_pos` for more information.
 ---@field save_win_pos? boolean
 ---
 ---Whether to set the `HOME` environmental variable; defaults to `true`.
----See |set_home_env| or `:help set_home_env` for more information.
+---Do `:help set_home_env` for more information.
 ---@field set_home_env? boolean
 ---
 ---Controls how R's `width` option is set by R.nvim; defaults to `2`,
 ---meaning the value will be set according to the initial width of the R
----console. See |setwidth| or `:help setwidth` for more information.
+---console. Do `:help setwidth` for more information.
 ---@field setwidth? boolean | integer
 ---
 ---Whether to display terminal error messages as warnings; defaults to
----`false`. See |silent_term| or `:help silent_term` for more information.
+---`false`. Do `:help silent_term` for more information.
 ---@field silent_term? boolean
 ---
---Optionally a path to the program Skim which may be used to open PDF files;
---defaults to '""'.
---@field private skim_app_path? string
+---Path to the program Skim which may be used to open PDF files;
+---defaults to '""'.
+---@field skim_app_path? string
 ---
 ---Additional arguments passed to `source()` when running R code; defaults to
----`""`. See |source_args| or `:help source_args` for more information.
+---`""`. Do `:help source_args` for more information.
 ---@field source_args? string
 ---
 ---Whether to use R.nvim's `nvim.plit()` on `<LocalLeader>rg`; defaults to
----`false`. See |specialplot| or `:help specialplot` for more information.
+---`false`. Do `:help specialplot` for more information.
 ---@field specialplot? boolean
 ---
 ---Packages for which to built autocompletions when R starts; defaults to
----`"base,stats,graphics,grDevices,utils,methods"`. See |start_libs| or
----`:help start_libs` for more information.
+---`"base,stats,graphics,grDevices,utils,methods"`. Do `:help start_libs` for
+---more information.
 ---@field start_libs? string
 ---
----Whether to use SyncTex with R.nvim; defaults to `true`. See |synctex| or
----`:help synctex` for more information.
+---Whether to use SyncTex with R.nvim; defaults to `true`. Do `:help synctex`
+---for more information.
 ---@field synctex? boolean
 ---
---The PID of R.nvim's terminal window. This is set internally.
---@field private term_pid? integer
---
---The title of R.nvim's terminal window. This is set internally.
---@field private term_title? string
---
 ---Controls the display of LaTeX errors and warnings; defaults to `true`
----to output these to the console. See |texerr| or `:help texerr` for more
----information.
+---to output these to the console. Do `:help texerr` for more information.
 ---@field texerr? boolean
 ---
 ---Can be used to set a particular directory to use for temporary files;
----defaults to `""` to use the OS default. See |tmpdir| or `:help tmpdir` for
----more information.
+---defaults to `""` to use the OS default. Do `:help tmpdir` for more
+---information.
 ---@field tmpdir? string
 ---
 --Internal variable used to store the user login name.
 --@field private user_login? string
 --
 ---If `true` then default keymaps will not be created; defaults to `false`.
----See |user_maps_only| or `:help user_maps_only` for more information.
+---Do `:help user_maps_only` for more information.
 ---@field user_maps_only? boolean
 ---
 ---Time to wait before loading the {nvimcom} package after starting R; defaults
----to `60` seconds. See |wait| or `:help wait` for more information.
+---to `60` seconds. Do `:help wait` for more information.
 ---@field wait? integer
 ---
 ---Set `params` based on the YAML header for R Markdown and
@@ -404,6 +386,11 @@ local hooks = require("r.hooks")
 ---@field source_read? string
 ---@field source_write? string
 ---@field curview? string
+---@field term_title? string -- Pid of window application.
+---@field term_pid? integer -- Part of the window title.
+---@field R_Tmux_pane? string
+---@field R_prompt_str? string
+---@field R_continue_str? string
 
 -- stylua: ignore start
 ---@type RConfig
@@ -450,6 +437,8 @@ local config = {
                           },
     insert_mode_cmds    = false,
     latexcmd            = { "default" },
+    latex_build_dir     = "",
+    sweaveargs          = "",
     listmethods         = false,
     local_R_library_dir = "",
     max_paste_lines     = 20,
@@ -501,8 +490,6 @@ local config = {
     specialplot         = false,
     start_libs          = "base,stats,graphics,grDevices,utils,methods",
     synctex             = true,
-    term_pid            = 0,
-    term_title          = "term",
     texerr              = true,
     tmpdir              = "",
     user_login          = "",
@@ -556,6 +543,9 @@ end
 local set_pdf_viewer = function()
     if config.is_darwin then
         config.pdfviewer = "skim"
+        if config.skim_app_path == "" then
+            config.skim_app_path = "/Applications/Skim.app"
+        end
     elseif config.is_windows then
         config.pdfviewer = "sumatra"
     else

--- a/lua/r/edit.lua
+++ b/lua/r/edit.lua
@@ -2,7 +2,7 @@ local config = require("r.config").get_config()
 local get_lang = require("r.utils").get_lang
 local warn = require("r.log").warn
 local del_list = {}
-local rscript_buf = nil
+local rscript_buf = 0
 local debug_info = { Time = {} }
 
 local M = {}

--- a/lua/r/external_term.lua
+++ b/lua/r/external_term.lua
@@ -4,7 +4,7 @@ local uv = vim.uv
 local warn = require("r.log").warn
 
 local term_name = nil
-local term_cmd = nil
+local term_cmd = ""
 local tmuxsname = nil
 
 -- local global_option_value = TmuxOption("some_option", "global")
@@ -21,7 +21,7 @@ local external_term_config = function()
         term_name = string.gsub(tostring(config.external_term), " .*", "")
         if string.find(tostring(config.external_term), " ") then
             -- Complete command defined by the user
-            term_cmd = config.external_term
+            term_cmd = tostring(config.external_term)
             return
         end
     end

--- a/lua/r/job.lua
+++ b/lua/r/job.lua
@@ -139,7 +139,7 @@ end
 --- Opens an R terminal with the specified command.
 ---@param cmd string The command to start the R terminal with.
 M.R_term_open = function(cmd)
-    local jobid = vim.fn.termopen(cmd, { on_exit = M.on_exit })
+    local jobid = vim.fn.jobstart(cmd, { on_exit = M.on_exit, term = true })
     if jobid == 0 then
         warn("Invalid arguments R in built-in terminal: " .. tostring(cmd))
     elseif jobid == -1 then

--- a/lua/r/pdf/skim.lua
+++ b/lua/r/pdf/skim.lua
@@ -5,7 +5,7 @@ local M = {}
 ---@param fullpath string
 M.open = function(fullpath)
     vim.fn.system(
-        config.macvim_skim_app_path
+        config.skim_app_path
             .. '/Contents/MacOS/Skim "'
             .. fullpath
             .. '" 2> /dev/null >/dev/null &'
@@ -19,7 +19,7 @@ end
 M.SyncTeX_forward = function(tpath, ppath, texln)
     -- This command is based on macvim-skim
     vim.fn.system(
-        config.macvim_skim_app_path
+        config.skim_app_path
             .. "/Contents/SharedSupport/displayline -r "
             .. texln
             .. ' "'

--- a/lua/r/rmd.lua
+++ b/lua/r/rmd.lua
@@ -225,7 +225,7 @@ M.setup = function()
         vim.api.nvim_buf_set_keymap(
             0,
             "i",
-            cfg.rmdchunk,
+            tostring(cfg.rmdchunk),
             "<Cmd>lua require('r.rmd').write_chunk()<CR>",
             { silent = true }
         )

--- a/lua/r/rnw.lua
+++ b/lua/r/rnw.lua
@@ -85,7 +85,7 @@ local SyncTeX_readconc = function(basenm)
         texidx = texidx + 1
         while i < max_i and texidx < ntexln do
             i = i + 1
-            local lnrange = vim.fn.range(1, concl[i])
+            local lnrange = vim.fn.range(1, tonumber(concl[i]))
             i = i + 1
             for _, _ in ipairs(lnrange) do
                 if texidx > ntexln then break end
@@ -222,7 +222,7 @@ end
 -- Because this function delete files, it will not be documented.
 -- If you want to try it, put in your config:
 --
--- let rm_knit_cache = true
+-- rm_knit_cache = true
 --
 -- If don't want to answer the question about deleting files, and
 -- if you trust this code more than I do, put in your config:
@@ -297,11 +297,11 @@ M.weave = function(bibtex, knit, pdf)
 
     if not pdf or config.open_pdf == "no" then pdfcmd = pdfcmd .. ", view = FALSE" end
 
-    if config.latex_build_dir then
+    if config.latex_build_dir ~= "" then
         pdfcmd = pdfcmd .. ', builddir="' .. config.latex_build_dir .. '"'
     end
 
-    if not knit and config.sweaveargs then
+    if not knit and config.sweaveargs ~= "" then
         pdfcmd = pdfcmd .. ", " .. config.sweaveargs
     end
 

--- a/lua/r/server.lua
+++ b/lua/r/server.lua
@@ -62,7 +62,7 @@ local init_stdout = function(_, data, _)
         out_line = ""
 
         -- In spite of flush(stdout()), rcmd might be concatenating two commands
-        local rcmdl = vim.fn.split(rcmd, "\020", 0)
+        local rcmdl = vim.fn.split(rcmd, "\020", false)
         for _, c in ipairs(rcmdl) do
             if c:find("^WARN: ") then
                 table.insert(b_warn, c:sub(7))

--- a/lua/r/term.lua
+++ b/lua/r/term.lua
@@ -110,6 +110,7 @@ local split_window = function()
 end
 
 M.reopen_win = function()
+    if not r_bufnr then return end
     local wlist = vim.api.nvim_list_wins()
     for _, wnr in ipairs(wlist) do
         if vim.api.nvim_win_get_buf(wnr) == r_bufnr then
@@ -172,8 +173,8 @@ M.highlight_term = function()
     if r_bufnr then vim.api.nvim_set_option_value("syntax", "rout", { buf = r_bufnr }) end
 end
 
----Return built-in termina buffer number
----@return number
+---Return built-in terminal buffer number
+---@return number | nil
 M.get_buf_nr = function() return r_bufnr end
 
 return M

--- a/lua/r/utils.lua
+++ b/lua/r/utils.lua
@@ -169,7 +169,6 @@ function M.ensure_directory_exists(dir_path)
 end
 
 local get_fw_info_X = function()
-    local config = require("r.config").get_config()
     local obj = M.system({ "xprop", "-root" }, { text = true }):wait()
     if obj.code ~= 0 then
         warn("Failed to run `xprop -root`")
@@ -215,6 +214,7 @@ local get_fw_info_X = function()
         )
         return
     end
+    local config = require("r.config").get_config()
     config.term_title = nm
     config.term_pid = tonumber(pid)
 end


### PR DESCRIPTION
- Avoid private fields in config class.
- Add missing fields to config class.
- Fix argument types.
- Remove vimdoc links from config.lua.