### PR TITLE
Enhance Quarto and RMarkdown support with new commands

### DIFF
--- a/lua/r/format/brackets.lua
+++ b/lua/r/format/brackets.lua
@@ -62,7 +62,7 @@ M.formatsubsetting = function(bufnr)
 
     local filetype = vim.bo[bufnr].filetype
     if filetype ~= "r" and filetype ~= "quarto" and filetype ~= "rmd" then
-        warn("This function is only available for R files.")
+        warn("This function is not available for " .. filetype .. " files.")
         return
     end
 

--- a/lua/r/format/brackets.lua
+++ b/lua/r/format/brackets.lua
@@ -60,7 +60,8 @@ M.formatsubsetting = function(bufnr)
 
     bufnr = bufnr or vim.api.nvim_get_current_buf()
 
-    if vim.bo[bufnr].filetype ~= "r" then
+    local filetype = vim.bo[bufnr].filetype
+    if filetype ~= "r" and filetype ~= "quarto" and filetype ~= "rmd" then
         warn("This function is only available for R files.")
         return
     end

--- a/lua/r/format/numbers.lua
+++ b/lua/r/format/numbers.lua
@@ -1,73 +1,83 @@
-local config = require("r.config").get_config()
+local inform = require("r.log").inform
+local get_r_chunks_from_quarto = require("r.quarto").get_r_chunks_from_quarto
+local get_root_node = require("r.utils").get_root_node
 
-local warn = require("r.log").warn
 local M = {}
 
--- We check if treesitter is available in the check_parsers() function of the
--- R.nvim plugin, so we can safely require the parsers module here.
-local parsers = require("nvim-treesitter.parsers")
+--- Find and replace floating point numbers in the given R content.
+-- @param r_content The R content as a string.
+-- @param bufnr The buffer number.
+-- @param chunk_start_row The starting row of the chunk.
+-- @param chunk_start_col The starting column of the chunk.
+local function find_and_replace_float(r_content, bufnr, chunk_start_row, chunk_start_col)
+    local r_parser = vim.treesitter.get_string_parser(r_content, "r")
+    local r_tree = r_parser:parse()[1]
+    local r_root = r_tree:root()
 
--- Define the Treesitter query
-local query = [[
-((float) @value (#lua-match? @value "^%d+$"))
-]]
+    local float_query = vim.treesitter.query.parse(
+        "r",
+        [[
+        ((float) @value (#lua-match? @value "^%d+$"))
+        ]]
+    )
 
-local function is_adjacent_char_colon(bufnr, start_row, start_col, end_row, end_col)
-    -- Check if the previous or the next character is a colon in order to not add an "L" to the number. Should return only true or false
-    local prev_char = vim.api.nvim_buf_get_text(
-        bufnr,
-        start_row,
-        start_col - 1,
-        start_row,
-        start_col,
-        {}
-    )[1]
+    local replacements = {}
+    for _, node in float_query:iter_captures(r_root, r_content) do
+        local start_row, start_col, end_row, end_col = node:range()
+        local float_text = vim.treesitter.get_node_text(node, r_content)
+        local new_text = float_text .. "L"
 
-    local next_char =
-        vim.api.nvim_buf_get_text(bufnr, end_row, end_col, end_row, end_col + 1, {})[1]
+        table.insert(replacements, {
+            start_row = chunk_start_row + start_row,
+            start_col = chunk_start_col + start_col,
+            end_row = chunk_start_row + end_row,
+            end_col = chunk_start_col + end_col,
+            text = new_text,
+        })
+    end
 
-    return prev_char == ":" or next_char == ":"
+    -- Apply replacements in reverse order
+    for i = #replacements, 1, -1 do
+        local repl = replacements[i]
+        vim.api.nvim_buf_set_text(
+            bufnr,
+            repl.start_row,
+            repl.start_col,
+            repl.end_row,
+            repl.end_col,
+            { repl.text }
+        )
+    end
 end
 
+--- Format numbers in the current buffer.
+-- This function formats numbers in R, Quarto, and RMarkdown files.
+-- It replaces floating point numbers with integers followed by 'L'.
+-- @param bufnr The buffer number (optional).
 M.formatnum = function(bufnr)
     bufnr = bufnr or vim.api.nvim_get_current_buf()
 
-    if vim.bo[bufnr].filetype ~= "r" then
-        warn("This function is only available for R files.")
+    local filetype = vim.bo[bufnr].filetype
+
+    if filetype ~= "r" and filetype ~= "quarto" and filetype ~= "rmd" then
+        inform("Not yet supported in '" .. filetype .. "' files.")
         return
     end
 
-    local lang = parsers.get_buf_lang(bufnr)
+    local root_node = get_root_node(bufnr)
+    if not root_node then return end
 
-    if not lang then return end
+    if filetype == "quarto" or filetype == "rmd" then
+        local r_chunks_content = get_r_chunks_from_quarto(root_node, bufnr)
 
-    local parser = parsers.get_parser(bufnr, lang)
-    local tree = parser:parse()[1]
-    local root = tree:root()
-
-    local query_obj = vim.treesitter.query.parse(lang, query)
-    -- local convert_range = config.convert_range_int
-
-    for _, node in query_obj:iter_captures(root, bufnr, 0, -1) do
-        local text = vim.treesitter.get_node_text(node, bufnr)
-
-        local start_row, start_col, end_row, end_col = node:range()
-
-        if
-            not (
-                is_adjacent_char_colon(bufnr, start_row, start_col, end_row, end_col)
-                and config.convert_range_int == false
-            )
-        then
-            vim.api.nvim_buf_set_text(
-                bufnr,
-                start_row,
-                start_col,
-                end_row,
-                end_col,
-                { text .. "L" }
-            )
+        for _, r_chunk in ipairs(r_chunks_content) do
+            find_and_replace_float(r_chunk.content, bufnr, r_chunk.start_row, 0)
         end
+    else
+        local buffer_content =
+            table.concat(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), "\n")
+
+        find_and_replace_float(buffer_content, bufnr, 0, 0)
     end
 end
 

--- a/lua/r/path.lua
+++ b/lua/r/path.lua
@@ -115,7 +115,9 @@ end
 --- Processes and formats the path found in the current Treesitter node.
 -- This function updates the path within the Treesitter node based on its type and context.
 M.separate = function()
-    local node = vim.treesitter.get_node()
+    local ts_utils = require("nvim-treesitter.ts_utils")
+    local node = ts_utils.get_node_at_cursor()
+
     if not node or node:type() ~= "string_content" then return end
 
     local string_node = node:parent()

--- a/lua/r/quarto.lua
+++ b/lua/r/quarto.lua
@@ -26,4 +26,38 @@ M.command = function(what)
     end
 end
 
+-- Helper function to get R content/code block from Quarto document
+-- @param root The root node of the parsed tree
+-- @param bufnr The buffer number
+-- @param cursor_pos The cursor position (optional)
+-- @return A table containing R code blocks with their content, start row and end row
+M.get_r_chunks_from_quarto = function(root, bufnr, cursor_pos)
+    local query = vim.treesitter.query.parse(
+        "markdown",
+        [[
+        (fenced_code_block
+          (info_string (language) @lang (#eq? @lang "r"))
+          (code_fence_content) @content)
+        ]]
+    )
+
+    bufnr = bufnr or vim.api.nvim_get_current_buf()
+
+    local r_contents = {}
+    for _, node, _ in query:iter_captures(root, bufnr, 0, -1) do
+        if node:type() == "code_fence_content" then
+            local start_row, _, end_row, _ = node:range()
+            if not cursor_pos or (cursor_pos >= start_row and cursor_pos <= end_row) then
+                table.insert(r_contents, {
+                    content = vim.treesitter.get_node_text(node, bufnr),
+                    start_row = start_row,
+                    end_row = end_row,
+                })
+                if cursor_pos then break end
+            end
+        end
+    end
+    return r_contents
+end
+
 return M

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -7,6 +7,7 @@ local edit = require("r.edit")
 local cursor = require("r.cursor")
 local paragraph = require("r.paragraph")
 local get_r_chunks_from_quarto = require("r.quarto").get_r_chunks_from_quarto
+local get_root_node = require("r.utils").get_root_node
 
 --- Check if line is a comment
 ---@param line string
@@ -737,25 +738,6 @@ M.chain = function()
     chain = sanatize_text(chain)
 
     M.source_lines(chain, nil)
-end
-
--- local get_root_node = function(bufnr)
---     local parser = vim.treesitter.get_parser(bufnr, "r", {})
---     if not parser then return nil end
---     local tree = parser:parse()[1]
---     return tree:root()
--- end
-
--- Helper function to get the root node
-local function get_root_node(bufnr)
-    bufnr = bufnr or vim.api.nvim_get_current_buf()
-    local parser = vim.treesitter.get_parser(bufnr)
-
-    if not parser then return nil end
-
-    local tree = parser:parse()[1]
-
-    return tree:root()
 end
 
 --- Extracts R functions from the given R content based on the query and cursor position.

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -800,16 +800,18 @@ local extract_r_functions = function(r_content, capture_all, cursor_pos, chunk_s
     return lines
 end
 
--- TODO: Test with Rmd files
 M.funs = function(bufnr, capture_all, move_down)
     bufnr = bufnr or vim.api.nvim_get_current_buf()
 
     local filetype = vim.bo[bufnr].filetype
-    if filetype ~= "r" and filetype ~= "rnoweb" and filetype ~= "quarto" then
-        vim.notify(
-            "Not yet supported in '" .. filetype .. "' files.",
-            vim.log.levels.WARN
-        )
+
+    if
+        filetype ~= "r"
+        and filetype ~= "rnoweb"
+        and filetype ~= "quarto"
+        and filetype ~= "rmd"
+    then
+        inform("Not yet supported in '" .. filetype .. "' files.")
         return
     end
 
@@ -820,7 +822,7 @@ M.funs = function(bufnr, capture_all, move_down)
 
     local lines = {}
 
-    if filetype == "quarto" then
+    if filetype == "quarto" or filetype == "rmd" then
         local r_chunks_content = get_r_chunks_from_quarto(root_node, bufnr)
 
         for _, r_chunk in ipairs(r_chunks_content) do

--- a/lua/r/utils.lua
+++ b/lua/r/utils.lua
@@ -501,4 +501,18 @@ function M.msg_join(x, sep, last, quote)
     return msg
 end
 
+--- Get the root node of the syntax tree for the given buffer.
+-- @param bufnr The buffer number (optional).
+-- @return The root node of the syntax tree, or nil if no parser is found.
+M.get_root_node = function(bufnr)
+    bufnr = bufnr or vim.api.nvim_get_current_buf()
+    local parser = vim.treesitter.get_parser(bufnr)
+
+    if not parser then return nil end
+
+    local tree = parser:parse()[1]
+
+    return tree:root()
+end
+
 return M


### PR DESCRIPTION
This pull request introduces several enhancements and refactors across multiple files to improve the handling and formatting of R content within Quarto and RMarkdown files (closes #316).

The following commands are now working for Quarto and RMarkdown documents:

- `<localleader>fa`
- `<localleader>fc`
- `<localleader>fd`
- `<localleader>sp`
- `<localleader>cn`
-  `<localleader>cs`