### PR TITLE
fix(send.lua): prevent cursor from moving beyond the last line by clamping end_row to buffer line count

### DIFF
--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -828,7 +828,8 @@ M.funs = function(bufnr, capture_all, move_down)
             local last_function = lines[#lines]
             local function_lines = vim.split(last_function, "\n")
             local end_row = vim.api.nvim_win_get_cursor(0)[1] + #function_lines
-            vim.api.nvim_win_set_cursor(0, { end_row, 0 })
+            local last_line = vim.api.nvim_buf_line_count(0)
+            vim.api.nvim_win_set_cursor(0, { math.min(end_row, last_line), 0 })
             vim.cmd("normal! j")
         end
     end


### PR DESCRIPTION
This fix a small issue when using the `<localleader>fd` in the case the function is at the end of the buffer.

For example, this R file with just this code:

```r
f1 <- function(x) {
  x + 1
}
```

With the cursor inside, press `<localleader>fd` and it will crash because we are trying to move the cursor past the end of the buffer.
