### PR TITLE
feat(buffer): add function to create R buffer from RMarkdown or Quart…

### DIFF
--- a/lua/r/buffer.lua
+++ b/lua/r/buffer.lua
@@ -1,0 +1,81 @@
+local inform = require("r.log").inform
+local warn = require("r.log").warn
+
+local M = {}
+
+local get_root_node = require("r.utils").get_root_node
+
+--- Creates an R buffer from the current buffer or a specified buffer number.
+--- If the current buffer is already an R file, it returns the current buffer number.
+--- For Quarto, or RMarkdown files, it extracts R code chunks and creates a new buffer.
+--- @return buffer|nil The buffer number of the created R buffer, or nil if creation fails.
+M.create_r_buffer = function()
+    local bufnr = vim.api.nvim_get_current_buf()
+
+    local filetype = vim.bo[bufnr].filetype
+
+    if filetype == "r" then return bufnr end
+
+    if filetype ~= "quarto" and filetype ~= "rmd" then
+        inform("Not yet supported in '" .. filetype .. "' files.")
+        return
+    end
+
+    local query = vim.treesitter.query.parse(
+        "markdown",
+        [[
+         (fenced_code_block
+           (info_string (language) @lang (#eq? @lang "r"))
+           (code_fence_content) @content)
+         ]]
+    )
+
+    local contents = {}
+    local last_end = 0
+
+    local root = get_root_node(bufnr)
+    if not root then return end
+
+    for id, node in query:iter_captures(root, bufnr, 0, -1) do
+        local start_row, _, end_row, _ = node:range()
+
+        -- Replace non-R content with blank lines
+        for _ = last_end, start_row - 1 do
+            table.insert(contents, "")
+        end
+
+        -- Add R chunk content
+        if query.captures[id] == "content" then
+            local chunk_content = vim.treesitter.get_node_text(node, bufnr)
+
+            -- Account for the chunk delimiter
+            table.insert(contents, "")
+            table.insert(contents, chunk_content)
+            table.insert(contents, "")
+        end
+
+        last_end = end_row + 1
+    end
+
+    -- Replace remaining non-R content at the end with blank lines
+    local buffer_line_count = vim.api.nvim_buf_line_count(bufnr)
+    for _ = last_end, buffer_line_count - 1 do
+        table.insert(contents, "")
+    end
+
+    local lines = table.concat(contents, "\n")
+
+    local rbuf = vim.api.nvim_create_buf(false, true)
+
+    if not rbuf then
+        warn("Failed to create R buffer.")
+        return
+    end
+
+    vim.api.nvim_buf_set_lines(rbuf, 0, -1, false, vim.split(lines, "\n"))
+    vim.bo[rbuf].filetype = "r"
+
+    return rbuf
+end
+
+return M

--- a/lua/r/maps.lua
+++ b/lua/r/maps.lua
@@ -231,9 +231,9 @@ local send = function(file_type)
     create_maps("ni",  "RDSendMBlock",     "bd", "<Cmd>lua require('r.send').marked_block(true)")
 
     -- Function
-    create_maps("nvi", "RSendAllFun",    "fa", "<Cmd>lua require('r.send').funs(0, true, false)")
-    create_maps("nvi", "RSendCurrentFun",   "fc", "<Cmd>lua require('r.send').funs(0, false, false)")
-    create_maps("nvi", "RDSendCurrentFun",   "fd", "<Cmd>lua require('r.send').funs(0, false, true)")
+    create_maps("nvi", "RSendAllFun",    "fa", "<Cmd>lua require('r.send').funs(true, false)")
+    create_maps("nvi", "RSendCurrentFun",   "fc", "<Cmd>lua require('r.send').funs(false, false)")
+    create_maps("nvi", "RDSendCurrentFun",   "fd", "<Cmd>lua require('r.send').funs(false, true)")
 
     -- Pipe chain breaker
     create_maps("nv", "RSendChain",      "sc", "<Cmd>lua require('r.send').chain()")

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -6,10 +6,7 @@ local get_lang = require("r.utils").get_lang
 local edit = require("r.edit")
 local cursor = require("r.cursor")
 local paragraph = require("r.paragraph")
-local get_r_chunks_from_quarto = require("r.quarto").get_r_chunks_from_quarto
-local get_root_node = require("r.utils").get_root_node
 
--- TODO: Find better name for this function and the module file
 local create_r_buffer = require("r.buffer").create_r_buffer
 
 --- Check if line is a comment
@@ -767,8 +764,6 @@ local r_fun_nodes = function(rbuf)
     local nodes = {}
 
     for _, node in query:iter_captures(root, rbuf, 0, -1) do
-        local start_row, _, end_row, _ = node:range()
-
         table.insert(nodes, node)
     end
 


### PR DESCRIPTION
This PR enables Tree-sitter support for QMD and RMD files. The core addition is the new function:  

https://github.com/R-nvim/R.nvim/blob/403e956d243397fb12681af66b5e775fbc48d9ff/lua/r/buffer.lua#L12-L79

This function creates a temporary R buffer by stripping out non-R code, allowing seamless integration with Tree-sitter tools. Instead of `vim.api.nvim_get_current_buf()`, we can now use `create_r_buffer()`, ensuring Tree-sitter operates on pure R content.  

As a practical example, I refactored the function-sending logic to the console. It now works transparently across different file types:  
https://github.com/R-nvim/R.nvim/blob/403e956d243397fb12681af66b5e775fbc48d9ff/lua/r/send.lua#L784
