### PR TITLE
docs(R.nvim.txt): remove outdated example of using Lua function for `open_app` configuration

### DIFF
--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -1957,18 +1957,7 @@ Calc:
    open_app = "localc"
    open_app = "c:/Program Files (x86)/LibreOffice 4/program/scalc.exe"
 <
-`open_app` can be a Lua function which will receive a single argument: the name
-of the `tsv` file. Example on how to see the first five lines as a
-notification:
->lua
-   view_df = {
-     n_lines = 5,
-     open_app = function(file_name)
-       local lines = vim.fn.readfile(file_name)
-       vim.notify(table.concat(lines, "\n"))
-     end
-   }
-<
+
 The substring `%s` is replaced by the name of the object under the cursor, and
 `()` are added if necessary. In this case, no `csv` file is saved (see also
 |R.nvim-key-bindings|).

--- a/lua/r/edit.lua
+++ b/lua/r/edit.lua
@@ -285,7 +285,7 @@ M.view_df = function(oname, txt)
         fname = oname
     end
 
-    if type(open_app) == "string" and open_app == "" then
+    if open_app == "" then
         if vim.fn.bufloaded(fname) == 1 then
             local sbopt = vim.o.switchbuf
             vim.o.switchbuf = "useopen,usetab"
@@ -323,11 +323,6 @@ M.view_df = function(oname, txt)
         vim.fn.writefile(csv_lines, tsvnm)
     end
     M.add_for_deletion(tsvnm)
-
-    if type(open_app) == "function" then
-        open_app(tsvnm)
-        return
-    end
 
     local cmd
     if open_app:find("%%s") then


### PR DESCRIPTION
Remove the example using a lua function for the `open_app` parameter, since we are now accepting only string.

https://github.com/R-nvim/R.nvim/blob/48c0cafdad3baddc350dea9d68f3bc3d1db3065a/lua/r/config.lua#L111