### PR TITLE
Enhance piped commands handling in R code using TreeSitter and remove obsolete utility functions

### DIFF
--- a/lua/r/buffer.lua
+++ b/lua/r/buffer.lua
@@ -8,7 +8,7 @@ local get_root_node = require("r.utils").get_root_node
 --- Creates an R buffer from the current buffer or a specified buffer number.
 --- If the current buffer is already an R file, it returns the current buffer number.
 --- For Quarto, or RMarkdown files, it extracts R code chunks and creates a new buffer.
---- @return buffer|nil The buffer number of the created R buffer, or nil if creation fails.
+--- @return integer|nil The buffer number of the created R buffer, or nil if creation fails.
 M.create_r_buffer = function()
     local bufnr = vim.api.nvim_get_current_buf()
 

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -716,7 +716,9 @@ M.chain = function()
     local sibling = nil
     local visited = false
 
-    for id, node, _ in call_query:iter_captures(root, bufnr, cursor_row, cursor_row + 1) do
+    local pipe_start_row, _, pipe_end_row = pipe_block_node:range()
+
+    for id, node, _ in call_query:iter_captures(root, bufnr, pipe_start_row, pipe_end_row) do
         local capture_name = call_query.captures[id]
         local start_row, _, end_row = node:range()
 

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -716,7 +716,7 @@ M.chain = function()
     local sibling = nil
     local visited = false
 
-    for id, node, _ in call_query:iter_captures(pipe_block_node, bufnr, 0, -1) do
+    for id, node, _ in call_query:iter_captures(root, bufnr, cursor_row, cursor_row + 1) do
         local capture_name = call_query.captures[id]
         local start_row, _, end_row = node:range()
 

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -740,7 +740,7 @@ end
 
 --- Retrieves R function nodes from a given buffer using TreeSitter.
 ---
---- @param rbuf buffer The buffer to analyze
+--- @param rbuf integer The buffer to analyze
 --- @return table A list of TreeSitter nodes representing R functions
 local r_fun_nodes = function(rbuf)
     local parser = vim.treesitter.get_parser(rbuf, "r")

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -663,19 +663,19 @@ M.chain = function()
         (_
             (binary_operator
                 lhs: (_)
-                operator: ([("|>") ("<-") ("+") ("special")]) 
-                rhs: (call) 
+                operator: ([("|>") ("<-") ("+") ("special")])
+                rhs: (call)
             ) @pipeline_no_assign
             (#not-has-parent? @pipeline_no_assign binary_operator)
-        )       
-  
+        )
+
         (_
             ; Handle when the pipeline is assignment to a variable
             (binary_operator
-                lhs: (identifier) 
+                lhs: (identifier)
                 rhs: (binary_operator
                     lhs: (_)
-                    operator: ([("|>") ("+") ("special")]) 
+                    operator: ([("|>") ("+") ("special")])
                     rhs: (call)
                 ) @pipeline_with_assign
             )


### PR DESCRIPTION
This pull request includes changes to the `lua/r/send.lua` file, focusing on improving the handling of piped commands in R code by leveraging TreeSitter for parsing and querying the syntax tree. 

The most important changes include the removal of several utility functions, the addition of a new function to handle the chain of piped commands, and the introduction of TreeSitter queries to identify and process specific syntax patterns.

Removed utility functions `ends_with`, `trim_lines`, `sanatize_text`, and `chain_start_at` as they are no longer needed with the new TreeSitter-based approach.


