### PR TITLE
refactor(numbers.lua, quarto.lua): generalize code chunk retrieval function

### DIFF
--- a/lua/r/format/numbers.lua
+++ b/lua/r/format/numbers.lua
@@ -1,6 +1,5 @@
 local inform = require("r.log").inform
 local get_code_chunk = require("r.quarto").get_code_chunk
-local get_root_node = require("r.utils").get_root_node
 
 local M = {}
 
@@ -64,11 +63,13 @@ M.formatnum = function(bufnr)
         return
     end
 
-    local root_node = get_root_node(bufnr)
-    if not root_node then return end
-
     if filetype == "quarto" or filetype == "rmd" then
-        local r_chunks_content = get_code_chunk(root_node, bufnr, nil, "r")
+        local r_chunks_content = get_code_chunk(bufnr, "r")
+
+        if not r_chunks_content then
+            error("Failed to extract code chunks.")
+            return
+        end
 
         for _, r_chunk in ipairs(r_chunks_content) do
             find_and_replace_float(r_chunk.content, bufnr, r_chunk.start_row, 0)

--- a/lua/r/format/numbers.lua
+++ b/lua/r/format/numbers.lua
@@ -1,5 +1,5 @@
 local inform = require("r.log").inform
-local get_r_chunks_from_quarto = require("r.quarto").get_r_chunks_from_quarto
+local get_code_chunk = require("r.quarto").get_code_chunk
 local get_root_node = require("r.utils").get_root_node
 
 local M = {}
@@ -68,7 +68,7 @@ M.formatnum = function(bufnr)
     if not root_node then return end
 
     if filetype == "quarto" or filetype == "rmd" then
-        local r_chunks_content = get_r_chunks_from_quarto(root_node, bufnr)
+        local r_chunks_content = get_code_chunk(root_node, bufnr, nil, "r")
 
         for _, r_chunk in ipairs(r_chunks_content) do
             find_and_replace_float(r_chunk.content, bufnr, r_chunk.start_row, 0)

--- a/lua/r/quarto.lua
+++ b/lua/r/quarto.lua
@@ -21,7 +21,7 @@ M.command = function(what)
     send_cmd(cmd)
 end
 
---- Find and replace floating point numbers in the given R content.
+--- Helper function to get code block from Rmd or Quarto document
 ---@param bufnr  integer The buffer number.
 ---@param lang string The language of the code chunk.
 ---@param row integer|nil The row number. If nil, all code chunks are returned.

--- a/lua/r/quarto.lua
+++ b/lua/r/quarto.lua
@@ -26,14 +26,17 @@ end
 -- @param bufnr The buffer number
 -- @param cursor_pos The cursor position (optional)
 -- @return A table containing R code blocks with their content, start row and end row
-M.get_r_chunks_from_quarto = function(root, bufnr, cursor_pos)
+M.get_code_chunk = function(root, bufnr, cursor_pos, code_fence_language)
     local query = vim.treesitter.query.parse(
         "markdown",
-        [[
-        (fenced_code_block
-          (info_string (language) @lang (#eq? @lang "r"))
-          (code_fence_content) @content)
-        ]]
+        string.format(
+            [[
+                (fenced_code_block
+                (info_string (language) @lang (#eq? @lang "%s"))
+                (code_fence_content) @content)
+            ]],
+            code_fence_language
+        )
     )
 
     bufnr = bufnr or vim.api.nvim_get_current_buf()

--- a/lua/r/quarto.lua
+++ b/lua/r/quarto.lua
@@ -21,12 +21,16 @@ M.command = function(what)
     send_cmd(cmd)
 end
 
--- Helper function to get R content/code block from Quarto document
--- @param root The root node of the parsed tree
--- @param bufnr The buffer number
--- @param cursor_pos The cursor position (optional)
--- @return A table containing R code blocks with their content, start row and end row
-M.get_code_chunk = function(root, bufnr, cursor_pos, code_fence_language)
+--- Find and replace floating point numbers in the given R content.
+---@param bufnr  integer The buffer number.
+---@param lang string The language of the code chunk.
+---@param row integer|nil The row number. If nil, all code chunks are returned.
+---@return table|nil
+M.get_code_chunk = function(bufnr, lang, row)
+    local root = require("r.utils").get_root_node()
+
+    if not root then return nil end
+
     local query = vim.treesitter.query.parse(
         "markdown",
         string.format(
@@ -35,7 +39,7 @@ M.get_code_chunk = function(root, bufnr, cursor_pos, code_fence_language)
                 (info_string (language) @lang (#eq? @lang "%s"))
                 (code_fence_content) @content)
             ]],
-            code_fence_language
+            lang
         )
     )
 
@@ -45,13 +49,13 @@ M.get_code_chunk = function(root, bufnr, cursor_pos, code_fence_language)
     for _, node, _ in query:iter_captures(root, bufnr, 0, -1) do
         if node:type() == "code_fence_content" then
             local start_row, _, end_row, _ = node:range()
-            if not cursor_pos or (cursor_pos >= start_row and cursor_pos <= end_row) then
+            if not row or (row >= start_row and row <= end_row) then
                 table.insert(r_contents, {
                     content = vim.treesitter.get_node_text(node, bufnr),
                     start_row = start_row,
                     end_row = end_row,
                 })
-                if cursor_pos then break end
+                if row then break end
             end
         end
     end


### PR DESCRIPTION
- Let us use the function to retrieve code chunks in a rmd/qmd document, so we can only use TS to capture any code chunk.

- If/when we refactor the send chunks functions, we could use it for both python and R. 

closes #338 