### PR TITLE
Minor refactor

### DIFF
--- a/lua/r/external_term.lua
+++ b/lua/r/external_term.lua
@@ -114,7 +114,7 @@ end
 
 local M = {}
 
-M.start_extern_term = function()
+M.start = function()
     if config.config_tmux then
         -- Create a custom tmux.conf
         local cnflines = {
@@ -165,7 +165,11 @@ M.start_extern_term = function()
         .. config.R_app
         .. rargs
 
-    open_cmd = term_cmd
+    open_cmd = {}
+    for _, v in pairs(term_cmd) do
+        table.insert(open_cmd, v)
+    end
+
     if
         vim.tbl_contains(term_cmd, "tmux") and vim.tbl_contains(term_cmd, "split%-window")
     then
@@ -238,7 +242,7 @@ end
 --- Send line of command to R Console
 ---@param command string
 ---@return boolean
-M.send_cmd_to_external_term = function(command)
+M.send_cmd = function(command)
     local cmd = command
 
     if config.clear_line then
@@ -290,6 +294,6 @@ end
 
 --- Return Tmux target name
 ---@return string
-M.get_tmuxsname = function() return tmuxsname end
+M.get_tmuxsname = function() return tmuxsname and tmuxsname or "" end
 
 return M

--- a/lua/r/rgui.lua
+++ b/lua/r/rgui.lua
@@ -1,0 +1,41 @@
+local config = require("r.config").get_config()
+local warn = require("r.log").warn
+
+local M = {}
+
+M.start = function()
+    vim.g.R_Nvim_status = 6
+
+    if config.R_app:find("Rterm") then
+        warn('"R_app" cannot be "Rterm.exe". R will crash if you send any command.')
+        vim.wait(200)
+    end
+
+    M.set_R_home()
+    vim.fn.system("start " .. config.R_app .. " " .. require("r.run").get_r_args())
+    M.unset_R_home()
+
+    require("r.run").wait_nvimcom_start()
+end
+
+-- Called by rnvimserver
+M.clean_and_start = function()
+    require("r.run").clear_R_info()
+    M.start()
+end
+
+---Send command to Rgui.exe
+---@param command string
+---@return boolean
+M.send_cmd = function(command)
+    local cmd
+    if config.clear_line then
+        cmd = "\001" .. "\013" .. command .. "\n"
+    else
+        cmd = command .. "\n"
+    end
+    require("r.job").stdin("Server", "83" .. cmd)
+    return true
+end
+
+return M

--- a/lua/r/rstudio.lua
+++ b/lua/r/rstudio.lua
@@ -2,7 +2,7 @@ local config = require("r.config").get_config()
 local warn = require("r.log").warn
 local M = {}
 
-M.start_RStudio = function()
+M.start = function()
     vim.g.R_Nvim_status = 6
 
     if config.is_windows then require("r.windows").set_R_home() end
@@ -21,7 +21,7 @@ end
 --- Send coommand to RStudio
 ---@param command string
 ---@return boolean
-M.send_cmd_to_RStudio = function(command)
+M.send_cmd = function(command)
     if not require("r.job").is_running("RStudio") then
         warn("Is RStudio running?")
         return false

--- a/lua/r/run.lua
+++ b/lua/r/run.lua
@@ -132,12 +132,12 @@ start_R2 = function()
 
     if config.RStudio_cmd ~= "" then
         vim.env.R_DEFAULT_PACKAGES = rdp .. ",rstudioapi"
-        require("r.rstudio").start_RStudio()
+        require("r.rstudio").start()
         return
     end
 
     if config.external_term == "" then
-        require("r.term").start_term()
+        require("r.term").start()
         return
     end
 
@@ -145,11 +145,11 @@ start_R2 = function()
         warn(
             "Support for running Rgui.exe may be removed. Please, see https://github.com/R-nvim/R.nvim/issues/308"
         )
-        require("r.windows").start_Rgui()
+        require("r.rgui").start()
         return
     end
 
-    require("r.external_term").start_extern_term()
+    require("r.external_term").start()
 end
 
 --- Return arguments to start R defined as config.R_args or during custom R

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -157,13 +157,13 @@ M.set_send_cmd_fun = function()
     end
 
     if config.RStudio_cmd ~= "" then
-        M.cmd = require("r.rstudio").send_cmd_to_RStudio
+        M.cmd = require("r.rstudio").send_cmd
     elseif config.external_term == "" then
-        M.cmd = require("r.term").send_cmd_to_term
+        M.cmd = require("r.term").send_cmd
     elseif config.is_windows then
-        M.cmd = require("r.windows").send_cmd_to_Rgui
+        M.cmd = require("r.rgui").send_cmd
     else
-        M.cmd = require("r.external_term").send_cmd_to_external_term
+        M.cmd = require("r.external_term").send_cmd
     end
 end
 

--- a/lua/r/term.lua
+++ b/lua/r/term.lua
@@ -9,7 +9,7 @@ local r_bufnr = nil
 ---Send command to R running a built-in terminal emulator
 ---@param command string
 ---@return boolean
-M.send_cmd_to_term = function(command)
+M.send_cmd = function(command)
     local is_running
     require("r.job").is_running("R")
     if is_running == 0 then
@@ -124,7 +124,7 @@ M.reopen_win = function()
     vim.cmd.sb(edbuf)
 end
 
-M.start_term = function()
+M.start = function()
     vim.g.R_Nvim_status = 6
 
     local edbuf = vim.api.nvim_get_current_buf()

--- a/lua/r/windows.lua
+++ b/lua/r/windows.lua
@@ -1,5 +1,4 @@
 local config = require("r.config").get_config()
-local warn = require("r.log").warn
 local saved_home = nil
 local M = {}
 
@@ -30,41 +29,6 @@ M.unset_R_home = function()
         vim.env.HOME = saved_home
         saved_home = nil
     end
-end
-
-M.start_Rgui = function()
-    vim.g.R_Nvim_status = 6
-
-    if config.R_app:find("Rterm") then
-        warn('"R_app" cannot be "Rterm.exe". R will crash if you send any command.')
-        vim.wait(200)
-    end
-
-    M.set_R_home()
-    vim.fn.system("start " .. config.R_app .. " " .. require("r.run").get_r_args())
-    M.unset_R_home()
-
-    require("r.run").wait_nvimcom_start()
-end
-
--- Called by rnvimserver
-M.clean_and_start_Rgui = function()
-    require("r.run").clear_R_info()
-    M.start_Rgui()
-end
-
----Send command to Rgui.exe
----@param command string
----@return boolean
-M.send_cmd_to_Rgui = function(command)
-    local cmd
-    if config.clear_line then
-        cmd = "\001" .. "\013" .. command .. "\n"
-    else
-        cmd = command .. "\n"
-    end
-    require("r.job").stdin("Server", "83" .. cmd)
-    return true
 end
 
 return M

--- a/nvimcom/DESCRIPTION
+++ b/nvimcom/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nvimcom
-Version: 0.9.63
-Date: 2025-02-17
+Version: 0.9.64
+Date: 2025-02-25
 Title: Intermediate the Communication Between R and Neovim
 Author: Jakson Aquino
 Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>

--- a/nvimcom/src/apps/rgui.c
+++ b/nvimcom/src/apps/rgui.c
@@ -225,7 +225,7 @@ void parse_rgui_msg(char *msg) {
             fprintf(stderr, "R was already started\n");
             fflush(stderr);
         } else {
-            printf("lua require('r.windows').clean_and_start_Rgui()\n");
+            printf("lua require('r.rgui').clean_and_start()\n");
             fflush(stdout);
         }
         break;


### PR DESCRIPTION
- Avoid repetion of module name in function name.
- Move Rgui functions to rgui.lua
- Also, deep copy table (Fix #346)