### PR TITLE
fix(lua): use raw string literals for Python code execution

### DIFF
--- a/lua/r/quarto.lua
+++ b/lua/r/quarto.lua
@@ -370,7 +370,7 @@ M.codelines_from_chunks = function(chunks)
         local content = chunk:get_content()
 
         if M.is_python(lang) then
-            table.insert(codelines, 'reticulate::py_run_string("' .. content .. '")')
+            table.insert(codelines, 'reticulate::py_run_string(r"(' .. content .. ')")')
         elseif M.is_r(lang) then
             table.insert(codelines, content)
         end

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -209,8 +209,7 @@ M.source_lines = function(lines, what)
             (vim.o.filetype == "rmd" or vim.o.filetype == "quarto")
             and utils.get_lang() == "python"
         then
-            rcmd = rcmd:gsub('"', '\\"')
-            rcmd = 'reticulate::py_run_string("' .. rcmd .. '")'
+            rcmd = 'reticulate::py_run_string(r"(' .. rcmd .. ')")'
         end
     else
         vim.fn.writefile(lines, config.source_write)
@@ -557,7 +556,7 @@ M.line = function(m)
         or vim.bo.filetype == "quarto"
     then
         if quarto.is_python(lang) then
-            line = 'reticulate::py_run_string("' .. line:gsub('"', '\\"') .. '")'
+            line = 'reticulate::py_run_string(r"(' .. line .. ')")'
             ok = M.cmd(line)
             if ok and m == true then cursor.move_next_line() end
             return


### PR DESCRIPTION
This pull request includes changes to improve the handling of Python code execution within R and Quarto documents by modifying the way strings are passed to the `reticulate::py_run_string` function. 

Fix crashes like this case where you have a print python function using `"`

````
```{python}
print("Hello")
```
````

This would crash if using with `localleader<ch>`.


### Improvements to Python code execution:

* [`lua/r/quarto.lua`](diffhunk://#diff-a628cdf45a9f0894d37ede53c461854baf4f8b048983d06183ea64ae08b33d5aL373-R373): Modified the `codelines_from_chunks` function to use raw string literals for Python code execution to handle special characters more effectively.
* [`lua/r/send.lua`](diffhunk://#diff-d49f74bb08746ae5d64f2873a7321f320961815717bceaca7adbbf0defb2d175L212-R212): Updated the `source_lines` function to use raw string literals for Python code execution, improving the handling of embedded quotes.
* [`lua/r/send.lua`](diffhunk://#diff-d49f74bb08746ae5d64f2873a7321f320961815717bceaca7adbbf0defb2d175L560-R559): Changed the `line` function to use raw string literals for Python code execution, simplifying the code and reducing the need for escaping quotes.Switch to using raw string literals in `reticulate::py_run_string` to handle special characters more effectively and avoid manual escaping. This change improves code readability and reduces potential errors in string handling.