### PR TITLE
fix(quarto.lua): correct logic for evaluating code chunks

### DIFF
--- a/lua/r/quarto.lua
+++ b/lua/r/quarto.lua
@@ -346,10 +346,10 @@ M.filter_code_chunks_by_eval = function(chunks)
 
         -- Check for eval in comment_params
         if chunk:get_comment_params() and chunk:get_comment_params().eval then
-            eval = chunk:get_comment_params().eval == "true"
+            eval = chunk:get_comment_params().eval ~= "true"
         -- Check for eval in info_string_params
         elseif chunk:get_info_string_params() and chunk:get_info_string_params().eval then
-            eval = chunk:get_info_string_params().eval == "TRUE"
+            eval = chunk:get_info_string_params().eval ~= "TRUE"
         end
 
         return eval -- Return true if eval is "true"

--- a/lua/r/quarto.lua
+++ b/lua/r/quarto.lua
@@ -346,10 +346,10 @@ M.filter_code_chunks_by_eval = function(chunks)
 
         -- Check for eval in comment_params
         if chunk:get_comment_params() and chunk:get_comment_params().eval then
-            eval = chunk:get_comment_params().eval ~= "true"
+            eval = chunk:get_comment_params().eval ~= "false"
         -- Check for eval in info_string_params
         elseif chunk:get_info_string_params() and chunk:get_info_string_params().eval then
-            eval = chunk:get_info_string_params().eval ~= "TRUE"
+            eval = chunk:get_info_string_params().eval ~= "FALSE"
         end
 
         return eval -- Return true if eval is "true"

--- a/lua/r/rmd.lua
+++ b/lua/r/rmd.lua
@@ -58,7 +58,6 @@ M.send_current_chunk = function(m)
 
     local chunks = quarto.get_current_code_chunk(bufnr)
 
-    chunks = quarto.filter_code_chunks_by_eval(chunks)
     chunks = quarto.filter_supported_langs(chunks)
 
     if #chunks == 0 then


### PR DESCRIPTION

This pull request includes a smal change to the `lua/r/quarto.lua` file. The change modifies the logic for evaluating code chunks based on their parameters.

* [`lua/r/quarto.lua`](diffhunk://#diff-a628cdf45a9f0894d37ede53c461854baf4f8b048983d06183ea64ae08b33d5aL349-R352): Updated the `M.filter_code_chunks_by_eval` function to correctly handle the `eval` parameter by changing the condition to check if `eval` is not equal to "true" or "TRUE" instead of equal to "true" or "TRUE".

It prevents running the chunk when is explicitly set to false.

See https://github.com/R-nvim/R.nvim/issues/359#issuecomment-2733887878