### PR TITLE
Fix minor nvimcom bugs

### DIFF
--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -774,7 +774,15 @@ details, please, access:
 
 
 ------------------------------------------------------------------------------
-5.7. Windows bugs and limitations
+5.6 Object Browser may display the wrong tree segment
+
+On the Libraries view of the Object Browser, if the last element of a library
+is a list, data.frame or S4 object, it will be prefixed by "|-" instead of
+"`-".
+
+
+------------------------------------------------------------------------------
+5.8. Windows bugs and limitations
 
 ------------------------------
 Wrong message that "R is busy"

--- a/nvimcom/DESCRIPTION
+++ b/nvimcom/DESCRIPTION
@@ -1,10 +1,10 @@
 Package: nvimcom
-Version: 0.9.71
-Date: 2025-07-07
+Version: 0.9.72
+Date: 2025-08-03
 Title: Intermediate the Communication Between R and Neovim
 Author: Jakson Aquino
 Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>
-Depends: R (>= 3.0.0)
+Depends: R (>= 4.1.0)
 Suggests: knitr, rmarkdown, quarto
 Imports: methods, tools
 Encoding: UTF-8

--- a/nvimcom/R/nvimcom.R
+++ b/nvimcom/R/nvimcom.R
@@ -79,15 +79,9 @@ NvimcomEnv$tcb <- FALSE
 #' detach("package:nvimcom", unload = TRUE)
 .onUnload <- function(libpath) {
     NvimcomEnv$tcb <- FALSE
-    if (is.loaded("nvimcom_Stop")) {
-        .C(nvimcom_Stop)
-        if (Sys.getenv("RNVIM_TMPDIR") != "" && .Platform$OS.type == "windows") {
-                unlink(paste0(Sys.getenv("RNVIM_TMPDIR"), "/rconsole_hwnd_",
-                              Sys.getenv("RNVIM_SECRET")))
-        }
-        Sys.sleep(0.2)
-        library.dynam.unload("nvimcom", libpath)
-    }
+    try(.C(nvimcom_Stop), silent = TRUE)
+    Sys.sleep(0.2)
+    try(library.dynam.unload("nvimcom", libpath), silent = TRUE)
 }
 
 run_tcb <- function(...) {

--- a/nvimcom/src/apps/data_structures.c
+++ b/nvimcom/src/apps/data_structures.c
@@ -269,7 +269,7 @@ static PkgData *get_pkg(const char *nm) {
     return NULL;
 }
 
-static char *get_pkg_descr(const char *pkgnm) {
+static char *get_pkg_descr(const char *pkgnm, int again) {
     Log("get_pkg_descr(%s)", pkgnm);
     InstLibs *il = instlibs;
     while (il) {
@@ -279,6 +279,10 @@ static char *get_pkg_descr(const char *pkgnm) {
             return s;
         }
         il = il->next;
+    }
+    if (again) {
+        update_inst_libs();
+        return get_pkg_descr(pkgnm, 0);
     }
     return NULL;
 }
@@ -428,7 +432,7 @@ static void load_pkg_data(PkgData *pd) {
     Log("load_pkg_data(%s)", pd->name);
     int size;
     if (!pd->descr)
-        pd->descr = get_pkg_descr(pd->name);
+        pd->descr = get_pkg_descr(pd->name, 1);
     pd->alias = read_alias_file(pd->name);
     pd->args = read_args_file(pd->name);
     if (!pd->objls) {
@@ -449,7 +453,7 @@ static PkgData *new_pkg_data(const char *nm, const char *vrsn) {
     strcpy(pd->name, nm);
     pd->version = malloc((strlen(vrsn) + 1) * sizeof(char));
     strcpy(pd->version, vrsn);
-    pd->descr = get_pkg_descr(pd->name);
+    pd->descr = get_pkg_descr(pd->name, 1);
     pd->loaded = 1;
 
     snprintf(buf, 1023, "%s/objls_%s_%s", compldir, nm, vrsn);


### PR DESCRIPTION
- Add new known bug to doc/R.nvim.txt.
- Make library description available immediately after installation.
- Require R 4.1.0 due to `\(x)` in misc.R
- More robust nvimcom unload