### PR TITLE
Treat Markdown as RMarkdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ firm commitment to backwards compatibility.
   chunk is sent to R and the cursor jumps to the next chunk of either R or
   Python code.
 
+- Markdown documents are treated as RMarkdown if "markdown" is in
+  `vim.g.R_filetypes`.
+
 ### New features
 
 #### New commands

--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -142,10 +142,11 @@ Suggestions for Unix (Linux, macOS, etc.):
 		 Required if you want to run R in an external terminal
 		 emulator and don't want to install Tmux.
 
-   Tmux >= 3.0:  http://tmux.sourceforge.net
-                 Tmux is required only if you want to run R in an external
-		 terminal emulator or in a Tmux split pane. Not required if
-		 either WezTerm or Kitty is installed (see |external_term|).
+   terminalgraphics:
+                 https://codeberg.org/djvanderlaan/terminalgraphics
+		 Required to plot graphics in the R Console.
+		 Requires WezTerm, Kitty, or other terminal emulator that
+		 supports the Terminal Graphics Protocol.
 
    colorout >= 1.3-1:
                  https://github.com/jalvesaq/colorout/releases
@@ -153,6 +154,11 @@ Suggestions for Unix (Linux, macOS, etc.):
                  (Mostly useful if running R in an external terminal emulator.
                  See |external_term|). You should put in your Rprofile:
                  `library(colorout)`
+
+   Tmux >= 3.0:  http://tmux.sourceforge.net
+                 Tmux is required only if you want to run R in an external
+		 terminal emulator or in a Tmux split pane. Not required if
+		 either WezTerm or Kitty is installed (see |external_term|).
 
 Suggestions for bibliographic completion from Zotero in RMarkdown (`.Rmd`),
 Quarto (`.qmd`), and Rnoweb (`.Rnw`) documents:
@@ -1927,7 +1933,7 @@ Browser buffer:
 ------------------------------------------------------------------------------
 6.29. Disable R.nvim commands                                 *user_maps_only*
                                                               *disable_cmds*
-                                                              *filetypes*
+                                                              *R_filetypes*
 
 The R.nvim sets many default key bindings, but you can change them to custom
 key bindings (|R.nvim-key-bindings|). If you wish R.nvim to only use the
@@ -1952,8 +1958,11 @@ If you want to disable R.nvim for a specific file type, create the variable
    vim.g.R_filetypes = { "r", "rmd", "rnoweb", "quarto", "rhelp" }
 <
 If the variable `R_filetypes` does not exist, all file types from the above
-list will be supported.
-
+list will be supported. Although not in the above list, "markdown" can be
+treated as "rmd" if you add it to the list:
+>lua
+   vim.g.R_filetypes = { "r", "rmd", "rnoweb", "quarto", "rhelp", "markdown" }
+<
 
 ------------------------------------------------------------------------------
 6.30. Temporary files directories                                   *tmpdir*

--- a/ftplugin/markdown_rnvim.lua
+++ b/ftplugin/markdown_rnvim.lua
@@ -1,0 +1,8 @@
+if
+    vim.fn.exists("g:R_filetypes") == 1
+    and type(vim.g.R_filetypes) == "table"
+    and vim.tbl_contains(vim.g.R_filetypes, "markdown")
+then
+    require("r.config").real_setup()
+    require("r.rmd").setup()
+end

--- a/ftplugin/quarto_rnvim.lua
+++ b/ftplugin/quarto_rnvim.lua
@@ -1,7 +1,7 @@
 if
     vim.fn.exists("g:R_filetypes") == 1
     and type(vim.g.R_filetypes) == "table"
-    and vim.fn.index(vim.g.R_filetypes, "quarto") == -1
+    and not vim.tbl_contains(vim.g.R_filetypes, "quarto")
 then
     return
 end

--- a/ftplugin/r_rnvim.lua
+++ b/ftplugin/r_rnvim.lua
@@ -1,7 +1,7 @@
 if
     vim.g.R_filetypes
     and type(vim.g.R_filetypes) == "table"
-    and vim.fn.index(vim.g.R_filetypes, "r") == -1
+    and not vim.tbl_contains(vim.g.R_filetypes, "r")
 then
     return
 end

--- a/ftplugin/rhelp_rnvim.lua
+++ b/ftplugin/rhelp_rnvim.lua
@@ -1,7 +1,7 @@
 if
     vim.g.R_filetypes
     and type(vim.g.R_filetypes) == "table"
-    and vim.fn.index(vim.g.R_filetypes, "rhelp") == -1
+    and not vim.tbl_contains(vim.g.R_filetypes, "rhelp")
 then
     return
 end

--- a/ftplugin/rmd_rnvim.lua
+++ b/ftplugin/rmd_rnvim.lua
@@ -1,7 +1,7 @@
 if
     vim.g.R_filetypes
     and type(vim.g.R_filetypes) == "table"
-    and vim.fn.index(vim.g.R_filetypes, "rmd") == -1
+    and not vim.tbl_contains(vim.g.R_filetypes, "rmd")
 then
     return
 end

--- a/ftplugin/rnoweb_rnvim.lua
+++ b/ftplugin/rnoweb_rnvim.lua
@@ -1,7 +1,7 @@
 if
     vim.g.R_filetypes
     and type(vim.g.R_filetypes) == "table"
-    and vim.fn.index(vim.g.R_filetypes, "rnoweb") == -1
+    and not vim.tbl_contains(vim.g.R_filetypes, "rnoweb")
 then
     return
 end

--- a/lua/r/buffer.lua
+++ b/lua/r/buffer.lua
@@ -16,7 +16,7 @@ M.create_r_buffer = function()
 
     if filetype == "r" then return bufnr end
 
-    if filetype ~= "quarto" and filetype ~= "rmd" then
+    if not vim.tbl_contains({ "markdown", "rmd", "quarto" }, filetype) then
         inform("Not yet supported in '" .. filetype .. "' files.")
         return
     end

--- a/lua/r/cursor.lua
+++ b/lua/r/cursor.lua
@@ -63,7 +63,10 @@ M.move_next_line = function()
         if filetype == "rnoweb" and string.sub(curline, 1, 1) == "@" then
             require("r.rnw").next_chunk()
             return
-        elseif (filetype == "rmd" or filetype == "quarto") and curline:find("^```$") then
+        elseif
+            vim.tbl_contains({ "markdown", "rmd", "quarto" }, filetype)
+            and curline:find("^```$")
+        then
             require("r.rmd").next_chunk()
             return
         end

--- a/lua/r/debug.lua
+++ b/lua/r/debug.lua
@@ -156,7 +156,9 @@ local find_func = function(srcref)
                 s.winnr = vim.api.nvim_get_current_win()
                 s.func_offset = s.func_offset - 1
                 if srcref == "<text>" then
-                    if vim.bo.filetype == "rmd" or vim.bo.filetype == "quarto" then
+                    if
+                        vim.tbl_contains({ "markdown", "rmd", "quarto" }, vim.bo.filetype)
+                    then
                         s.func_offset = vim.fn.search("^\\s*```\\s*{\\s*r", "nb")
                     elseif vim.bo.filetype == "rnoweb" then
                         s.func_offset = vim.fn.search("^<<", "nb")

--- a/lua/r/edit.lua
+++ b/lua/r/edit.lua
@@ -94,16 +94,17 @@ M.pipe = function()
 end
 
 M.buf_enter = function()
-    if
-        vim.o.filetype == "r"
-        or vim.o.filetype == "rnoweb"
-        or vim.o.filetype == "rmd"
-        or vim.o.filetype == "quarto"
-        or vim.o.filetype == "rhelp"
-    then
-        rscript_buf = vim.api.nvim_get_current_buf()
+    if vim.g.R_filetypes then
+        if vim.tbl_contains(vim.g.R_filetypes, vim.o.filetype) then
+            rscript_buf = vim.api.nvim_get_current_buf()
+        end
+    else
+        local rft = { "r", "rnoweb", "rmd", "markdown", "quarto", "rhelp" }
+        if vim.tbl_contains(rft, vim.o.filetype) then
+            rscript_buf = vim.api.nvim_get_current_buf()
+        end
     end
-    if vim.o.filetype == "rmd" or vim.o.filetype == "quarto" then
+    if vim.tbl_contains({ "markdown", "rmd", "quarto" }, vim.o.filetype) then
         require("r.rmd").update_params()
     end
 end

--- a/lua/r/format/brackets.lua
+++ b/lua/r/format/brackets.lua
@@ -61,7 +61,8 @@ M.formatsubsetting = function(bufnr)
     bufnr = bufnr or vim.api.nvim_get_current_buf()
 
     local filetype = vim.bo[bufnr].filetype
-    if filetype ~= "r" and filetype ~= "quarto" and filetype ~= "rmd" then
+
+    if not vim.tbl_contains({ "r", "markdown", "rmd", "quarto" }, filetype) then
         warn("This function is not available for " .. filetype .. " files.")
         return
     end

--- a/lua/r/maps.lua
+++ b/lua/r/maps.lua
@@ -240,7 +240,7 @@ end
 local edit = function(file_type)
     create_maps("i", "RInsertPipe", ",", "<Cmd>lua require('r.edit').pipe()", 2)
     create_maps("i", "RInsertAssign", "<M-->", "<Cmd>lua require('r.edit').assign()", 3)
-    if file_type == "rmd" or file_type == "quarto" then
+    if vim.tbl_contains({ "markdown", "rmd", "quarto" }, file_type) then
         create_maps("i", "RmdInsertChunk", "<M-r>", "<Cmd>lua require('r.rmd').write_chunk()", 3)
     end
     if file_type == "rnoweb" then
@@ -292,7 +292,7 @@ local send = function(file_type)
         create_maps("ni",  "RSendFile",       "aa", "<Cmd>lua require('r.send').source_file()")
         create_maps("ni",  "RShowRout",       "ao", "<Cmd>lua require('r').show_R_out()")
     end
-    if file_type == "rmd" or file_type == "quarto" then
+    if vim.tbl_contains({ "markdown", "rmd", "quarto" }, file_type) then
         create_maps("nvi", "RKnit",           "kn", "<Cmd>lua require('r.run').knit()")
         create_maps("ni",  "RSendChunk",      "cc", "<Cmd>lua require('r.rmd').send_current_chunk(false)")
         create_maps("ni",  "RDSendChunk",     "cd", "<Cmd>lua require('r.rmd').send_current_chunk(true)")
@@ -321,7 +321,7 @@ local send = function(file_type)
         create_maps("n", "RNextRChunk",     "gn", "<Cmd>lua require('r.rnw').next_chunk()")
         create_maps("n", "RPreviousRChunk", "gN", "<Cmd>lua require('r.rnw').previous_chunk()")
     end
-    if file_type == "rnoweb" or file_type == "rmd" or file_type == "quarto" then
+    if vim.tbl_contains({ "rnoweb", "markdown", "rmd", "quarto" }, file_type) then
         create_maps("ni", "RSendChunkFH", "ch", "<Cmd>lua require('r.send').chunks_up_to_here()")
         if config.rm_knit_cache then
             create_maps("nvi", "RKnitRmCache", "kc", "<Cmd>lua require('r.rnw').rm_knit_cache()")

--- a/lua/r/paragraph.lua
+++ b/lua/r/paragraph.lua
@@ -18,7 +18,7 @@ M.get_current = function()
             line == ""
             or (vim.o.filetype == "rnoweb" and line:find("^<<"))
             or (
-                (vim.o.filetype == "rmd" or vim.o.filetype == "quarto")
+                vim.tbl_contains({ "markdown", "rmd", "quarto" }, vim.o.filetype)
                 and line:find("^```%{")
             )
         then

--- a/lua/r/run.lua
+++ b/lua/r/run.lua
@@ -326,7 +326,7 @@ M.set_nvimcom_info = function(nvimcomversion, rpid, wid, r_info)
     vim.g.R_Nvim_status = 7
     if
         config.set_params ~= "no"
-        and (vim.o.filetype == "quarto" or vim.o.filetype == "rmd")
+        and vim.tbl_contains({ "markdown", "rmd", "quarto" }, vim.o.filetype)
         and require("r.rmd").params_status() == "new"
     then
         local bn = vim.api.nvim_buf_get_name(0)

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -442,7 +442,7 @@ M.selection = function(m)
     local lang = utils.get_lang()
 
     if
-        (vim.o.filetype == "rmd" or vim.o.filetype == "quarto")
+        vim.tbl_contains({ "markdown", "rmd", "quarto" }, vim.o.filetype)
         and not quarto.is_supported_lang(lang)
         and not vim.api.nvim_get_current_line():find("`r ")
     then
@@ -553,11 +553,7 @@ M.line = function(m)
 
     local ok = false
 
-    if
-        vim.bo.filetype == "rnoweb"
-        or vim.bo.filetype == "rmd"
-        or vim.bo.filetype == "quarto"
-    then
+    if vim.tbl_contains({ "rnoweb", "markdown", "rmd", "quarto" }, vim.bo.filetype) then
         if quarto.is_python(lang) then
             line = 'reticulate::py_run_string(r"(' .. line .. ')")'
             ok = M.cmd(line)

--- a/lua/r/utils.lua
+++ b/lua/r/utils.lua
@@ -85,7 +85,7 @@ function M.get_lang()
     if filetype == "rhelp" then return get_rhelp_lang() end
 
     -- Handle quarto/rmd code blocks
-    if filetype == "quarto" or filetype == "rmd" then
+    if vim.tbl_contains({ "markdown", "rmd", "quarto" }, filetype) then
         local current_chunk =
             quarto.get_current_code_chunk(vim.api.nvim_get_current_buf())
         if current_chunk and current_chunk.lang then return current_chunk:get_lang() end


### PR DESCRIPTION
- When editing a Markdown document, behave as it were a RMarkdown one if "markdown" in included in the list `vim.g.R_filetypes` (close #422).