### PR TITLE
fix word document not opening in libreoffice after rendering markdown

### DIFF
--- a/lua/r/doc.lua
+++ b/lua/r/doc.lua
@@ -235,7 +235,7 @@ M.open = function(fullpath, browser)
         return
     end
     if fullpath:match(".odt$") or fullpath:match(".docx$") then
-        vim.system({ "lowriter ", fullpath })
+        vim.system({ "lowriter", fullpath })
     elseif fullpath:match(".pdf$") then
         require("r.pdf").open(fullpath)
     elseif fullpath:match(".html$") then


### PR DESCRIPTION
running:
     nvim version v0.11.3
     tmux version 3.5a
     R 4.5.0
     OS Debian 13

Rendering markdown document to docx format works but throws an error complaining about lowriter not being available. Removing the trailing space after the 'lowriter' command fixed the issue for me... Not sure if the same bug happens with other OS/software, or if a pull request is the best way to report this.

Anyways, hope this is helpful in any way. :)
