### PR TITLE
Fix yaml_hl

### DIFF
--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -1778,13 +1778,13 @@ config, as in the examples:
 R.nvim changes the background color of code blocks and adds a virtual text
 with the language of the code block to the right side of the header of the
 block. It also highlights YAML comments (prefixed with `#|`) with the
-foreground color of the tree-sitter highlighting group `@define` and comments
-prefixed with `# %%` with the foreground color of `@delimiter`. The background
-color is taken from |hl-CursorColumn| and the highlighting is updated on the
-|BufEnter| and |InsertLeave| events. The code of chunks with the field `eval:
-false` are highlighted with foreground color of |hl-Comment|, and chunks with
-the field `child` are highlighted with the foreground color of |hl-Ignore|.
-Below is an example of how to configure the highlighting:
+foreground color of the tree-sitter highlighting group `@attribute` and
+comments prefixed with `# %%` with the foreground color of `@string.special`.
+The background color is taken from |hl-CursorColumn| and the highlighting is
+updated on the |BufEnter| and |InsertLeave| events. The code of chunks with
+the field `eval: false` are highlighted with foreground color of |hl-Comment|,
+and chunks with the field `child` are highlighted with the foreground color of
+|hl-Ignore|. Below is an example of how to configure the highlighting:
 >lua
    quarto_chunk_hl = {
      highlight = false,               -- Highlight code blocks?

--- a/lua/r/rmd.lua
+++ b/lua/r/rmd.lua
@@ -238,9 +238,9 @@ local setup_yaml_hl = function()
         [[
 ; extends
 ; From quarto.nvim, YAML header for code blocks.
-((comment) @comment (#match? @comment "^\\#\\|")) @define
+((comment) @comment (#match? @comment "^\\#\\|")) @attribute
 ; Cell delimiter for Jupyter
-((comment) @content (#match? @content "^\\# ?\\%\\%")) @delimiter
+((comment) @content (#match? @content "^\\# ?\\%\\%")) @string.special
 ]]
     )
 
@@ -250,9 +250,9 @@ local setup_yaml_hl = function()
         [[
 ; extends
 ; YAML header for code blocks
-((comment) @comment (#match? @comment "^\\#\\|")) @define
+((comment) @comment (#match? @comment "^\\#\\|")) @attribute
 ; Cell delimiter for Jupyter
-((comment) @content (#match? @content "^\\# ?\\%\\%")) @class.outer @delimiter
+((comment) @content (#match? @content "^\\# ?\\%\\%")) @class.outer @string.special
 ]]
     )
 end


### PR DESCRIPTION
When trying to highlight YAML comments and Jupyter delimiters in RMarkdown and Quarto documents, we are linking them to non-default tree-sitter highlight groups: `@include` and `@delimiter`. Unless the user has defined these highlight groups, the highlighting would fail. This pull request changes the highlight groups to `@attribute` and `@string.special`. I tryied it with the color schemes "habamax" and "tokyonight". Example of code to test the highlighting:

````rmd

Normal text here.

```{r}
#| output: false
#| echo: false

# Normal comment

aa <- rnorm(100)
```

Normal text here.

```{python}
#| label: setxvalue

#%% This is a Jupyter delimiter

x = 10
print(x)
```

````