### PR TITLE
feat(nvimcom): add names completion for s7 objects

### DIFF
--- a/nvimcom/R/misc.R
+++ b/nvimcom/R/misc.R
@@ -429,7 +429,7 @@ nvim.plot <- function(x) {
 nvim.names <- function(x) {
     if (isS4(x)) {
         slotNames(x)
-    } else if ("S7_object" %in% class(x)) {
+    } else if (inherits(x, 'S7_object')) {
         names(attributes(x))
     } else {
         names(x)


### PR DESCRIPTION
This provides support for S7 property completion with the `@` trigger. I saw that S7 support was added to cmp-r and tried using S7 but `nvimcom::nvim.names` wasn't completing the slot/properties with the `@` trigger because `names()` is not a method for S7 objects. Using the object attributes names nvimcom can access S7 properties without having to load the S7 package.

If you're waiting for S7 to be included in base R feel free to close.