### PR TITLE
Ensure the :checkhealth window gets the focus when the temporary buffer is closed

### DIFF
--- a/lua/r/health.lua
+++ b/lua/r/health.lua
@@ -15,116 +15,6 @@ local function parser_installed(parser_name)
     ) or pcall(vim.treesitter.query.get, parser_name, "highlights")
 end
 
---- Create a buffer and check the languages at different cursor positions
----@return table
-local check_buffer = function(ft, lines, langs)
-    local health_win = vim.api.nvim_get_current_win()
-
-    -- Create a temporary buffer in a temporary window
-    local b = vim.api.nvim_create_buf(false, false)
-    vim.api.nvim_set_option_value("bufhidden", "wipe", { scope = "local" })
-    vim.api.nvim_set_option_value("number", false, { scope = "local" })
-    vim.api.nvim_set_option_value("swapfile", false, { scope = "local" })
-    vim.api.nvim_set_option_value("buftype", "nofile", { scope = "local" })
-    local w = vim.api.nvim_open_win(b, true, {
-        relative = "win",
-        row = 1,
-        col = 1,
-        width = 20,
-        height = 13,
-        hide = true,
-    })
-
-    vim.api.nvim_buf_set_lines(b, 0, -1, false, lines)
-    vim.api.nvim_set_option_value("filetype", ft, { buf = b })
-    vim.cmd("redraw")
-
-    -- Wait for treesitter to parse the buffer, likely a racing issue here
-    vim.wait(100)
-
-    for k, v in pairs(langs) do
-        vim.api.nvim_win_set_cursor(w, { v[2], v[3] })
-        langs[k][4] = require("r.utils").get_lang()
-    end
-
-    vim.api.nvim_set_current_win(health_win)
-
-    vim.api.nvim_win_close(w, true)
-    vim.api.nvim_buf_delete(b, { force = true })
-
-    return langs
-end
-
-local print_lang_check = function(langtbl)
-    for _, v in pairs(langtbl) do
-        if v[1] == v[4] then
-            vim.health.ok("Correctly detected: `" .. v[1] .. "`")
-        else
-            vim.health.error("Wrongly detected: `" .. v[1] .. "` vs `" .. v[4] .. "`")
-        end
-    end
-end
-
---- Check if language detection using treesitter is working
-local check_lang = function()
-    -- Quarto document
-    local lines = {
-        "---",
-        "title: Test",
-        "---",
-        "",
-        "Normal text.",
-        "",
-        "```{r}",
-        "x <- 1",
-        "```",
-        "",
-        "Normal text again.",
-    }
-
-    -- Expected language at different cursor positions
-    local qlangs = {
-        { "yaml", 2, 0, "" },
-        { "markdown", 4, 0, "" },
-        { "markdown_inline", 5, 0, "" },
-        { "r", 8, 0, "" },
-    }
-
-    qlangs = check_buffer("quarto", lines, qlangs)
-
-    -- Rnoweb document
-    lines = {
-        "\\documentclass{article}",
-        "\\begin{document}",
-        "",
-        "Normal text.",
-        "",
-        "<<example>>=",
-        "x <- 1",
-        "@",
-        "",
-        "Normal text again.",
-        "",
-        "\\end{document}",
-    }
-
-    -- Expected language at different cursor positions
-    local nlangs = {
-        { "latex", 4, 0, "" },
-        { "chunk_header", 6, 0, "" },
-        { "r", 7, 0, "" },
-        { "chunk_end", 8, 0, "" },
-    }
-
-    nlangs = check_buffer("rnoweb", lines, nlangs)
-
-    vim.health.start("Checking language detection in a Quarto document:")
-    print_lang_check(qlangs)
-
-    vim.health.start("Checking language detection in an Rnoweb document:")
-    print_lang_check(nlangs)
-end
-
 M.check = function()
     vim.health.start("Checking applications and plugins:")
 
@@ -186,8 +76,6 @@ M.check = function()
             vim.health.error("`" .. parser .. "` " .. "not found.")
         end
     end
-
-    check_lang()
 end
 
 return M


### PR DESCRIPTION
This pull request fixes #457 by ensuring that the original health window gets the focus as soon as the temporary window which is used to check the functionality of the tree-sitter parsers is closed. Please note the issue does not seem to be reproducible on other machines but I don't see how this change would have an impact on other functioning setups.