### PR TITLE
Fix missing functions in help.R

### DIFF
--- a/nvimcom/DESCRIPTION
+++ b/nvimcom/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nvimcom
-Version: 0.9.80
-Date: 2025-12-12
+Version: 0.9.81
+Date: 2025-12-20
 Title: Intermediate the Communication Between R and Neovim
 Author: Jakson Aquino
 Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>

--- a/nvimcom/R/help.R
+++ b/nvimcom/R/help.R
@@ -61,7 +61,7 @@ nvim.help <- function(topic, w, firstobj, pkg) {
         if (!inherits(ret, "try-error")) {
             suppressMessages(print(ret))
             return(invisible(NULL))
-        } else if (!missing(pkg) && pkgload::is_dev_pkg(pkg)) {
+        } else if (!missing(pkg) && pkgload::is_dev_package(pkg)) {
             warn(ret)
             return(invisible(NULL))
         }
@@ -72,7 +72,7 @@ nvim.help <- function(topic, w, firstobj, pkg) {
 
         if (!inherits(ret, "try-error")) {
             return(invisible(NULL))
-        } else if (!missing(pkg) && pkg %in% devtools::dev_pkgs()) {
+        } else if (!missing(pkg) && pkg %in% devtools::dev_packages()) {
             warn(ret)
             return(invisible(NULL))
         }


### PR DESCRIPTION
Fixes #477: running help on functions correctly returns the help, without errorr-ing out on the if statements.

This was introduced by #449 when stuff was renamed from `package` to `pkg`.

