### PR TITLE
feat: add RStartHorizontal and RStartVertical mappings

### DIFF
--- a/lua/r/maps.lua
+++ b/lua/r/maps.lua
@@ -9,6 +9,8 @@ local map_desc = {
     RSaveClose          = { m = "", k = "", c = "Start",    d = "Quit R, saving the workspace" },
     RClose              = { m = "", k = "", c = "Start",    d = "Send to R: quit(save = 'no')" },
     RStart              = { m = "", k = "", c = "Start",    d = "Start R with default configuration or reopen terminal window" },
+    RStartHorizontal    = { m = "", k = "", c = "Start",    d = "Start R in a horizontal split (50/50)" },
+    RStartVertical      = { m = "", k = "", c = "Start",    d = "Start R in a vertical split (50/50)" },
     RInsertAssign       = { m = "", k = "", c = "Edit",     d = "Insert ` <- `" },
     RInsertPipe         = { m = "", k = "", c = "Edit",     d = "Insert ` |>` (or ` %>%`)" },
     ROpenPDF            = { m = "", k = "", c = "Edit",     d = "Open the PDF generated from the current document" },
@@ -229,8 +231,10 @@ end
 
 local start = function()
     -- Start
-    create_maps("nvi", "RStart",       "rf", "<Cmd>lua require('r.run').start_R('R')")
-    create_maps("nvi", "RCustomStart", "rc", "<Cmd>lua require('r.run').start_R('custom')")
+    create_maps("nvi", "RStart",           "rf",  "<Cmd>lua require('r.run').start_R('R')")
+    create_maps("nvi", "RCustomStart",     "rc",  "<Cmd>lua require('r.run').start_R('custom')")
+    create_maps("nvi", "RStartHorizontal", "rfh", "<Cmd>lua require('r.run').start_R('R', 'horizontal')")
+    create_maps("nvi", "RStartVertical",   "rfv", "<Cmd>lua require('r.run').start_R('R', 'vertical')")
 
     -- Close
     create_maps("nvi", "RClose",       "rq", "<Cmd>lua require('r.run').quit_R('nosave')")

--- a/lua/r/run.lua
+++ b/lua/r/run.lua
@@ -7,6 +7,7 @@ local send = require("r.send")
 local cursor = require("r.cursor")
 local hooks = require("r.hooks")
 local what_R = "R"
+local split_override = nil
 local R_pid = 0
 local r_args
 local nseconds
@@ -134,7 +135,8 @@ start_R2 = function()
     end
 
     if config.external_term == "" then
-        require("r.term.builtin").start()
+        require("r.term.builtin").start(split_override)
+        split_override = nil
         return
     end
 
@@ -180,10 +182,10 @@ M.set_rns_port = function(p)
     vim.env.RNVIM_PORT = p
 end
 
-M.start_R = function(whatr)
+M.start_R = function(whatr, split)
     -- R started and nvimcom loaded
     if vim.g.R_Nvim_status == 7 then
-        if config.external_term == "" then require("r.term.builtin").reopen_win() end
+        if config.external_term == "" then require("r.term.builtin").reopen_win(split) end
         return
     end
 
@@ -218,6 +220,7 @@ M.start_R = function(whatr)
         require("r.send").set_send_cmd_fun()
         require("r.lsp").send_msg({ code = "1" })
         what_R = whatr
+        split_override = split
         vim.fn.timer_start(30, start_R2)
         return
     end

--- a/lua/r/term/builtin.lua
+++ b/lua/r/term/builtin.lua
@@ -68,7 +68,18 @@ M.close_term = function()
     r_bufnr = nil
 end
 
-local split_window = function()
+local split_window = function(direction)
+    if direction == "horizontal" then
+        local height = math.floor(vim.o.lines / 2)
+        vim.cmd("silent exe 'belowright " .. height .. "new'")
+        return
+    elseif direction == "vertical" then
+        local width = math.floor(vim.o.columns / 2)
+        vim.cmd("silent exe 'belowright " .. width .. "vnew'")
+        return
+    end
+
+    -- Original logic when no direction override
     local nw = vim.o.number and vim.o.numberwidth or 0
     local sw = config.rconsole_width + config.min_editor_width + 1 + nw
     if config.rconsole_width > 0 and vim.fn.winwidth(0) > sw then
@@ -92,7 +103,7 @@ local split_window = function()
     end
 end
 
-M.reopen_win = function()
+M.reopen_win = function(direction)
     if not r_bufnr then return end
     local wlist = vim.api.nvim_list_wins()
     for _, wnr in ipairs(wlist) do
@@ -102,18 +113,18 @@ M.reopen_win = function()
         end
     end
     local edbuf = vim.api.nvim_get_current_buf()
-    split_window()
+    split_window(direction)
     vim.api.nvim_win_set_buf(0, r_bufnr)
     vim.cmd.sb(edbuf)
 end
 
-M.start = function()
+M.start = function(direction)
     vim.g.R_Nvim_status = 6
 
     local edbuf = vim.api.nvim_get_current_buf()
     vim.o.switchbuf = "useopen"
 
-    split_window()
+    split_window(direction)
 
     if config.is_windows then require("r.windows").set_R_home() end
     require("r.job").R_term_open(config.R_app .. " " .. require("r.run").get_r_args())


### PR DESCRIPTION
## Summary

- Add `<Plug>RStartHorizontal` (`\rfh`) and `<Plug>RStartVertical` (`\rfv`) mappings that let users start R with an explicit 50/50 split direction
- Direction is passed as a clean function parameter through `start_R` → `start_R2` → `builtin.start` → `split_window`, with no config mutation
- The existing `\rf` mapping and all config-based split logic remain unchanged

## Motivation

Currently, the R console split direction is determined statically at config time via `rconsole_width` and `rconsole_height`. Users who switch between wide monitors (prefer vertical) and laptops (prefer horizontal) must change their config manually. These mappings let users choose the split direction at start time.

## Design decisions

- **50/50 split is hardcoded** — uses `math.floor(vim.o.columns / 2)` for vertical, `math.floor(vim.o.lines / 2)` for horizontal. User can resize manually afterwards.
- **`\rf` prefix is extended** — `\rfh` and `\rfv` build on the existing `\rf` prefix. With which-key or similar plugins, pressing `\rf` will show a menu with the available options (`\rf` for default, `\rfh` for horizontal, `\rfv` for vertical). Without such plugins, `\rf` still fires after `timeoutlen`.
- **Reopen respects direction** — If R is already running and the user presses `\rfh`, the console reopens horizontally.
- **No config mutation** — Direction is passed as a function parameter, not by modifying the config object.
- **Non-builtin terminals unaffected** — The `split` parameter only applies to the built-in terminal path; external terminals ignore it.

## Test plan

- [ ] Open an R file, press `\rfv` → R console should appear in a vertical 50/50 split
- [ ] Close the R console window, press `\rfh` → R console should reopen horizontally at 50/50
- [ ] Press `\rf` (wait for timeout) → original config-based split logic still works
- [ ] Test with `user_maps_only = true` → default keys disabled but `<Plug>RStartHorizontal`/`<Plug>RStartVertical` still available