### PR TITLE
feat: make insert_commented (\o) pipe-chain aware

### DIFF
--- a/lua/r/run.lua
+++ b/lua/r/run.lua
@@ -482,9 +482,7 @@ M.insert_commented = function()
         local clean = cur:gsub("%s*#.*$", "")
         paren_depth = paren_depth + count_pat(clean, "%(") - count_pat(clean, "%)")
         if last == total_lines then break end
-        if paren_depth > 0 then
-            last = last + 1
-        elseif ends_with_pipe(cur) then
+        if paren_depth > 0 or ends_with_pipe(cur) then
             last = last + 1
         else
             break


### PR DESCRIPTION
## Summary

- `insert_commented` (`\o`) now detects multi-line pipe chains and sends the full expression instead of just the current line
- Supports `|>`, `%>%`, `%<>%`, and `%T>%` operators
- Tracks parenthesis depth to handle multi-line function arguments (e.g., `mutate(\n...\n)`)
- Output is inserted as a comment below the last line of the chain
- Single-line behavior is unchanged

## Motivation

Currently, pressing `\o` on any line of a multi-line pipe chain like:

```r
c(3, 1, 4, 1, 5) |>
  sort() |>
  rev()
```

only sends that single line (e.g., `print(c(3, 1, 4, 1, 5) |>)`), which is an incomplete expression — R produces no output. Pipe chains are arguably the most common multi-line pattern in modern R, so this is a significant usability gap.

Similarly, pipes into multi-line function calls like:

```r
tokens <- tokens |>
    mutate(
      n_pred = 1 / (rang + beta)^alpha,
      residuals = n - n_pred
    )
```

are now correctly captured as a complete expression by tracking `(`/`)` depth.

## Approach

Uses a text-based line-walking heuristic with parenthesis depth tracking:

- **Walk up**: from the cursor, walk upward while the previous line ends with a pipe operator or while there are unmatched `)` needing a `(` above
- **Walk down**: from the chain start, walk forward while inside unclosed parentheses (`depth > 0`) or while the line ends with a pipe operator

The collected lines are joined with spaces (not newlines) to avoid issues in the Lua → LSP → rnvimserver → R transport layer.

This avoids the complexity of treesitter (and the synthetic buffer mapping needed for Quarto/Rmd) while covering all practical cases.

## Test plan

- [x] Single line, no pipes: cursor on `x <- 5`, press `\o` → `# [1] 5` below (unchanged behavior)
- [x] Multi-line native pipe: cursor anywhere in `data |> filter() |> summarize()` chain → full chain evaluated, output below last line
- [x] Pipe with multi-line function args: `tokens |> mutate(\n...\n)` → complete expression captured
- [x] Pipe with assignment: `result <- data |> filter()` → assigns and prints
- [x] Trailing comments stripped: `rev() # comment` → comment removed before sending
- [ ] Multi-line magrittr pipe: same with `%>%`
- [ ] Works in Quarto/Rmd R chunks