### PR TITLE
fix(run.lua): replace backslashes in command to prevent escape issues in insert_commented()

### DIFF
--- a/lua/r/run.lua
+++ b/lua/r/run.lua
@@ -427,6 +427,7 @@ end
 ---@param type string
 M.insert = function(cmd, type)
     if vim.g.R_Nvim_status < 7 then return end
+    cmd = cmd:gsub("\\", "\020")
     cmd = cmd:gsub("'", "\018")
     cmd = cmd:gsub('"', "\019")
     M.send_to_nvimcom("E", "nvimcom:::nvim_insert(" .. cmd .. ", '" .. type .. "')")
@@ -445,15 +446,11 @@ M.insert_commented = function()
         local lines = {}
         for line in code:gmatch("[^\n]+") do
             local stripped = line:gsub("%s*#.*", "")
-            if stripped:match("%S") then
-                table.insert(lines, stripped)
-            end
+            if stripped:match("%S") then table.insert(lines, stripped) end
         end
         code = table.concat(lines, " ")
         -- Move cursor to end of chain
-        if end_row then
-            vim.api.nvim_win_set_cursor(0, { end_row, 0 })
-        end
+        if end_row then vim.api.nvim_win_set_cursor(0, { end_row, 0 }) end
     else
         -- Fallback to single line
         code = vim.api.nvim_get_current_line():gsub("%s*#.*", "")

--- a/nvimcom/src/nvimcom.c
+++ b/nvimcom/src/nvimcom.c
@@ -784,6 +784,13 @@ static char *unscape_str(const char *a) {
                 b[j] = '"';
                 j++;
                 i += 6;
+            } else if (a[i + 5] == '4') {
+                b[j] = '\\';
+                j++;
+                i += 6;
+            } else {
+                // unknown \u001X: skip to avoid infinite loop
+                i += 6;
             }
         } else {
             b[j] = a[i];


### PR DESCRIPTION
There was some bad escaping in the last commit (659dc18aba2d).

Use this:

```lua
:lua require('r.run').insert_commented()
```

On this:

```r
# Bad
gsub("\\d+", "X", "abc123def456")
# [1] "abc123def456"
```

With these changes:

```r
# Good
gsub("\\d+", "X", "abc123def456")
# [1] "abcXdefX"
```