### PR TITLE
feat(config.lua, utils.lua): add use_git_files option to improve file search efficiency

### DIFF
--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -1477,12 +1477,13 @@ Alternatively, you can disable or change R.nvim's built-in language server
 features in your R.nvim config. Below are the default values:
 >lua
  r_ls = {
-    completion = true,     -- enable the completion provider
-    hover = true,          -- enable the hover provider
-    signature = true,      -- enable the signature help provider
-    implementation = true, -- enable the implementation provider
-    definition = true,     -- enable the definition provider
-    references = true,     -- enable the references provider
+    completion = true,        -- enable the completion provider
+    hover = true,             -- enable the hover provider
+    signature = true,         -- enable the signature help provider
+    implementation = true,    -- enable the implementation provider
+    definition = true,        -- enable the definition provider
+    use_git_files = true,     -- use git to find R files, skipping gitignored files
+    references = true,        -- enable the references provider
     doc_width = 0,
     fun_data_1 = { "select", "rename", "mutate", "filter" },
     fun_data_2 = { ggplot = { "aes" }, with = { "*" } },
@@ -1501,6 +1502,11 @@ Meaning of options:
 
   - `implementation`: Enable the implementation provider
   - `definition`: Enable the definition provider
+
+  - `use_git_files`: Use `git ls-files` to find R files when indexing the
+    workspace, skipping files ignored by `.gitignore`. This dramatically
+    improves performance in large git repositories. Falls back to recursive
+    directory scan if git is unavailable. Default: `true`.
 
   - `references`: Enable the references provider
 

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -15,6 +15,10 @@ local hooks = require("r.hooks")
 ---Enable the definition provider
 ---@field definition? boolean
 ---
+---Use git to find workspace R files, respecting .gitignore; falls back to
+---recursive scan if git is unavailable or the directory is not a repository
+---@field use_git_files? boolean
+---
 ---Enable the references provider
 ---@field references? boolean
 ---
@@ -459,6 +463,7 @@ local config = {
         hover = true,
         signature = true,
         definition = true,
+        use_git_files = true,
         references = true,
         implementation = true,
         doc_width = 0,

--- a/lua/r/lsp/utils.lua
+++ b/lua/r/lsp/utils.lua
@@ -25,9 +25,7 @@ local M = {}
 local function is_top_level(node)
     local current = node:parent()
     while current do
-        if current:type() == "function_definition" then
-            return false
-        end
+        if current:type() == "function_definition" then return false end
         current = current:parent()
     end
     return true
@@ -242,6 +240,37 @@ end
 ---@param max_depth? integer Maximum recursion depth (default 10)
 ---@param current_depth? integer Current depth
 function M.find_r_files(dir, files, max_depth, current_depth)
+    -- On the first call, try git if use_git_files is enabled. This is much
+    -- faster for large projects that contains thousands of files but only a
+    -- few R source files. If it fails (not a git repo or git not available),
+    -- fall back to recursive scan.
+    if not current_depth then
+        local cfg = require("r.config").get_config()
+        if cfg.r_ls.use_git_files then
+            local git_root = vim.fn
+                .system(
+                    "git -C "
+                        .. vim.fn.shellescape(dir)
+                        .. " rev-parse --show-toplevel 2>/dev/null"
+                )
+                :gsub("\n$", "")
+            if vim.v.shell_error == 0 and git_root ~= "" then
+                local output = vim.fn.systemlist(
+                    "git -C "
+                        .. vim.fn.shellescape(dir)
+                        .. " ls-files --cached --others --exclude-standard --full-name"
+                        .. " -- '*.R' '*.r' '*.Rmd' '*.rmd' '*.qmd'"
+                )
+                if vim.v.shell_error == 0 then
+                    for _, rel in ipairs(output) do
+                        if rel ~= "" then table.insert(files, git_root .. "/" .. rel) end
+                    end
+                    return
+                end
+            end
+        end
+    end
+
     max_depth = max_depth or 10
     current_depth = current_depth or 0
 


### PR DESCRIPTION
When working in large projects (>1M data files for example), goto definition is noticeably slow (on the first use) because R.nvim searches all R files to build scope definitions, including files not tracked by git (build artifacts, caches, generated files, etc.).

The new `use_git_files` option skips git ignored files during file search, dramatically improving performance in large git repositories.