### PR TITLE
feat(lsp): add targets pipeline symbol recognition for goto-definition and find-references

### DIFF
--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -1515,6 +1515,14 @@ Meaning of options:
 
   - `references`: Enable the references provider
 
+Note: The definition and references providers also recognize symbols defined
+in `{targets}` pipelines. Target-defining calls (e.g., `tar_target()`,
+`tar_file()`) where the first argument is an unquoted identifier are indexed
+as symbol definitions. Consumer calls such as `tar_read()` and `tar_load()`
+are treated as references, not definitions. This means you can use
+goto-definition and find-references to navigate between targets in your
+pipeline.
+
   - `doc_width`: The expected maximum width of the floating documentation
     window. The default value will be between 30 and 80 columns, depending
     on the screen width.

--- a/lua/r/lsp/queries.lua
+++ b/lua/r/lsp/queries.lua
@@ -9,7 +9,6 @@ local M = {}
 local query_cache = {}
 
 --- Query string definitions (copied from original utils.lua)
--- TODO: Maybe add targets nodes so we can search in target pipeline? Maybe use a config option?
 local query_strings = {
     definitions = [[
         ; Function assignments with <- operator
@@ -47,6 +46,19 @@ local query_strings = {
             lhs: (identifier) @var_name
             operator: "="
             rhs: (_) @var_value) @var_definition
+
+        ; Target pipeline definitions: tar_target(name, ...), tar_file(name, ...), etc.
+        ; First positional argument is the target name (unquoted identifier).
+        ; Uses a broad ^tar_ match to support extension packages (tarchetypes, etc.).
+        ; Excludes known consumer functions (tar_read*, tar_load*) which reference existing targets.
+        (call
+            function: (identifier) @_tar_fn
+            (#match? @_tar_fn "^tar_")
+            (#not-match? @_tar_fn "^tar_read")
+            (#not-match? @_tar_fn "^tar_load")
+            arguments: (arguments
+                . (argument
+                    value: (identifier) @target_name))) @target_definition
     ]],
 
     references = [[

--- a/lua/r/lsp/scope.lua
+++ b/lua/r/lsp/scope.lua
@@ -175,7 +175,7 @@ local function find_definition_with_custom_query(
     local matches = {}
     for id, node in query:iter_captures(search_node, bufnr) do
         local capture_name = query.captures[id]
-        if capture_name == "name" or capture_name == "var_name" then
+        if capture_name == "name" or capture_name == "var_name" or capture_name == "target_name" then
             local text = vim.treesitter.get_node_text(node, bufnr)
             if text == symbol then
                 local start_row, start_col = node:start()

--- a/lua/r/lsp/utils.lua
+++ b/lua/r/lsp/utils.lua
@@ -204,6 +204,70 @@ function M.extract_symbols(bufnr, options)
                 end
             end
         end
+
+        -- Handle targets pipeline definitions (tar_target, etc.)
+        if capture_name == "target_definition" then
+            local call_node = node
+            if call_node and call_node:type() == "call" then
+                local args_node = call_node:field("arguments")[1]
+                if args_node then
+                    -- Get first argument (the target name)
+                    local first_arg
+                    for child in args_node:iter_children() do
+                        if child:type() == "argument" then
+                            first_arg = child
+                            break
+                        end
+                    end
+
+                    if first_arg then
+                        local value_node = first_arg:field("value")[1]
+                        if value_node and value_node:type() == "identifier" then
+                            local name = vim.treesitter.get_node_text(value_node, bufnr)
+
+                            if
+                                (not options.symbol_name or name == options.symbol_name)
+                                and (
+                                    not options.top_level_only or is_top_level(call_node)
+                                )
+                            then
+                                local name_start_row, name_start_col = value_node:start()
+                                local name_end_row, name_end_col = value_node:end_()
+                                local def_start_row, def_start_col = call_node:start()
+                                local def_end_row, def_end_col = call_node:end_()
+
+                                local key = string.format(
+                                    "%s:%d:%d",
+                                    name,
+                                    name_start_row,
+                                    name_start_col
+                                )
+                                if not seen[key] then
+                                    seen[key] = true
+                                    table.insert(
+                                        symbols,
+                                        create_symbol_info(
+                                            name,
+                                            13, -- Variable
+                                            file,
+                                            name_start_row,
+                                            name_start_col,
+                                            name_end_row,
+                                            name_end_col,
+                                            def_start_row,
+                                            def_start_col,
+                                            def_end_row,
+                                            def_end_col,
+                                            "target"
+                                        )
+                                    )
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+        end
     end
 
     return symbols

--- a/tests/test_goto_definition_spec.lua
+++ b/tests/test_goto_definition_spec.lua
@@ -114,6 +114,71 @@ outer <- function() {
         end)
     end)
 
+    describe("targets pipeline", function()
+        it("extracts tar_target symbol via find_in_current_buffer", function()
+            local content = "tar_target(my_data, read.csv('file.csv'))"
+            setup_test(content, { 1, 11 })
+            local matches = definition_module.find_in_current_buffer("my_data")
+            assert.equals(1, #matches)
+            assert.equals(0, matches[1].line)
+            assert.equals(11, matches[1].col)
+        end)
+
+        it("finds each tar_target in a typical pipeline list", function()
+            local content = [[
+list(
+    tar_target(raw, get_data()),
+    tar_target(clean, process(raw)),
+    tar_target(result, analyze(clean))
+)]]
+            setup_test(content, { 1, 0 })
+            local raw = definition_module.find_in_current_buffer("raw")
+            assert.equals(1, #raw)
+            assert.equals(1, raw[1].line)
+            assert.equals(15, raw[1].col)
+
+            local clean = definition_module.find_in_current_buffer("clean")
+            assert.equals(1, #clean)
+            assert.equals(2, clean[1].line)
+            assert.equals(15, clean[1].col)
+
+            local result = definition_module.find_in_current_buffer("result")
+            assert.equals(1, #result)
+            assert.equals(3, result[1].line)
+            assert.equals(15, result[1].col)
+        end)
+
+        it("does not treat non-tar_target calls as target definitions", function()
+            local content = "some_func(my_data, 42)"
+            setup_test(content, { 1, 0 })
+            local matches = definition_module.find_in_current_buffer("my_data")
+            assert.equals(0, #matches)
+        end)
+
+        it("finds tar_file symbol", function()
+            local content = "tar_file(report, generate_report(data))"
+            setup_test(content, { 1, 0 })
+            local matches = definition_module.find_in_current_buffer("report")
+            assert.equals(1, #matches)
+            assert.equals(0, matches[1].line)
+            assert.equals(9, matches[1].col)
+        end)
+
+        it("jumps from target reference to tar_target definition", function()
+            local content = "list(\n    tar_target(raw, get_data()),\n    tar_target(clean, process(raw)),\n    tar_target(result, analyze(clean))\n)\nprocess(raw)"
+            setup_test(content, { 6, 9 })
+            definition_module.goto_definition("req_targets_goto")
+            assert_location_response("req_targets_goto", 1, 15)
+        end)
+
+        it("does not treat tar_read as a definition", function()
+            local content = "tar_read(my_data)"
+            setup_test(content, { 1, 0 })
+            local matches = definition_module.find_in_current_buffer("my_data")
+            assert.equals(0, #matches)
+        end)
+    end)
+
     describe("edge cases", function()
         it("handles empty buffer", function()
             setup_test("", { 1, 0 })


### PR DESCRIPTION
Basically, it is just adding support for `targets` symbols.

![Peek 2026-03-14 13-37](https://github.com/user-attachments/assets/c48a8a5c-ca01-436c-b0ec-8111b9b48798)
