### PR TITLE
Ensure that variables defined in nested functions are correctly resolved

### DIFF
--- a/lua/r/lsp/ast.lua
+++ b/lua/r/lsp/ast.lua
@@ -61,6 +61,29 @@ function M.find_ancestor(node, node_types)
     return nil
 end
 
+--- Walk up tree to find ancestor of type, stopping at a boundary node
+---@param node TSNode Starting node
+---@param node_types string|string[] Single type or array of types
+---@param boundary TSNode Stop walking when this node is reached (exclusive)
+---@return TSNode?
+function M.find_ancestor_until(node, node_types, boundary)
+    if type(node_types) == "string" then
+        node_types = { node_types }
+    end
+
+    local current = node:parent()
+    while current and current ~= boundary do
+        for _, node_type in ipairs(node_types) do
+            if current:type() == node_type then
+                return current
+            end
+        end
+        current = current:parent()
+    end
+
+    return nil
+end
+
 --- Walk up tree collecting all ancestors of type
 ---@param node TSNode Starting node
 ---@param node_type string Node type to collect

--- a/lua/r/lsp/scope.lua
+++ b/lua/r/lsp/scope.lua
@@ -76,7 +76,9 @@ local function find_definition_with_locals(
     for id, node in query:iter_captures(scope_node, bufnr) do
         if query.captures[id] == "local.definition" then
             local text = vim.treesitter.get_node_text(node, bufnr)
-            if text == symbol then
+            if text == symbol
+                and not ast.find_ancestor_until(node, "function_definition", scope_node)
+            then
                 local is_parameter = ast.find_ancestor(node, { "parameter", "argument" })
                     ~= nil
 
@@ -177,7 +179,9 @@ local function find_definition_with_custom_query(
         local capture_name = query.captures[id]
         if capture_name == "name" or capture_name == "var_name" or capture_name == "target_name" then
             local text = vim.treesitter.get_node_text(node, bufnr)
-            if text == symbol then
+            if text == symbol
+                and not ast.find_ancestor_until(node, "function_definition", search_node)
+            then
                 local start_row, start_col = node:start()
                 -- Only consider assignments before the cursor
                 if

--- a/tests/test_scope_spec.lua
+++ b/tests/test_scope_spec.lua
@@ -176,6 +176,100 @@ outer <- function() {
             assert.equals(4, def.location.line)
         end)
 
+        it("does not leak nested function definitions into outer scope", function()
+            local content = [[
+x <- 100
+outer <- function() {
+    x <- 200
+    inner <- function() {
+        x <- 300
+        result <- x
+    }
+    print(x)
+}
+]]
+            local bufnr = setup_test(content, { 8, 10 })
+            local scope = scope_module.get_scope_at_position(bufnr, 7, 10) -- print(x) line
+            local def = scope_module.resolve_symbol("x", scope)
+
+            assert.is_not_nil(def)
+            assert.equals("x", def.name)
+            -- Should resolve to x <- 200 (line 2, 0-indexed), NOT x <- 300 inside inner
+            assert.equals(2, def.location.line)
+        end)
+
+        it("does not leak variables between sibling functions", function()
+            local content = [[
+func_a <- function() {
+    x <- 10
+}
+func_b <- function() {
+    print(x)
+}
+]]
+            local bufnr = setup_test(content, { 7, 10 })
+            local scope = scope_module.get_scope_at_position(bufnr, 6, 10) -- print(x) in func_b
+            local def = scope_module.resolve_symbol("x", scope)
+
+            -- x from func_a should NOT be visible in func_b
+            assert.is_nil(def)
+        end)
+
+        it("does not resolve forward references", function()
+            local content = [[
+my_func <- function() {
+    print(x)
+    x <- 42
+}
+]]
+            local bufnr = setup_test(content, { 2, 10 })
+            local scope = scope_module.get_scope_at_position(bufnr, 1, 10) -- print(x) line
+            local def = scope_module.resolve_symbol("x", scope)
+
+            -- x is defined AFTER cursor, should not resolve
+            assert.is_nil(def)
+        end)
+
+        it("resolves to middle scope in triple nesting", function()
+            local content = [[
+x <- 1
+outer <- function() {
+    x <- 2
+    middle <- function() {
+        x <- 3
+        inner <- function() {
+            x <- 4
+        }
+        print(x)
+    }
+}
+]]
+            local bufnr = setup_test(content, { 9, 14 })
+            local scope = scope_module.get_scope_at_position(bufnr, 8, 14) -- print(x) in middle
+            local def = scope_module.resolve_symbol("x", scope)
+
+            assert.is_not_nil(def)
+            assert.equals("x", def.name)
+            -- Should resolve to x <- 3 (line 4), not x <- 4 inside inner
+            assert.equals(4, def.location.line)
+        end)
+
+        it("resolves <<- super-assignment in scope", function()
+            local content = [[
+my_func <- function() {
+    x <<- 100
+    print(x)
+}
+]]
+            local bufnr = setup_test(content, { 3, 10 })
+            local scope = scope_module.get_scope_at_position(bufnr, 2, 10) -- print(x) line
+            local def = scope_module.resolve_symbol("x", scope)
+
+            assert.is_not_nil(def)
+            assert.equals("x", def.name)
+            assert.equals(1, def.location.line)
+        end)
+
         it("returns nil for undefined symbol", function()
             local content = [[
 x <- 42


### PR DESCRIPTION
I found a bug this morning while working.

With this code:

```r
# Nested function test
outer <- function() {
  x <- 20 # Shadows file-level x

  inner <- function() {
    x <- 30 # Shadows outer x
    print(x) # Should resolve to 30
  }

  print(x) #  ← cursor on x, it should resolve to 20
  inner()
}
```

With the current implementation, it was resolving to `x <- 30` in the `inner()` function. I have added some guards to respect scope boundaries. It should now resolve to `x <- 20` as expected.

I also added more tests with various nesting levels to make sure all is resolved ok.

