### PR TITLE
feat(R.nvim): add support for workspace symbol provider

### DIFF
--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -538,7 +538,6 @@ provides the server-side response.
 Note: This feature requires Neovim's built-in LSP client and will only work
 if `vim.lsp.config` is available (Neovim 0.11+).
 
-
 ------------------------------------------------------------------------------
 4.4. The Object Browser
 
@@ -1549,6 +1548,7 @@ features in your R.nvim config. Below are the default values:
     references = true,          -- enable the references provider
     document_highlight = true,  -- enable the document highlight provider
     document_symbol = true,     -- enable the document symbol provider
+    workspace_symbols = true,   -- enable the workspace symbol provider
     doc_width = 0,
     fun_data_1 = { "select", "rename", "mutate", "filter" },
     fun_data_2 = { ggplot = { "aes" }, with = { "*" } },
@@ -1577,6 +1577,10 @@ Meaning of options:
 
   - `document_highlight`: Enable the document highlight provider (see
     |R.nvim-doc-highlight|)
+
+  - `document_symbol`: Enable the document symbol provider
+
+  - `workspace_symbols`: Enable the workspace symbol provider
 
 Note: The definition and references providers also recognize symbols defined
 in `{targets}` pipelines. Target-defining calls (e.g., `tar_target()`,
@@ -2697,3 +2701,5 @@ See: https://www.vim.org/scripts/script.php?script_id=2628
 
 
 vim:tw=78:ts=8:ft=help:norl
+
+

--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -1548,7 +1548,7 @@ features in your R.nvim config. Below are the default values:
     references = true,          -- enable the references provider
     document_highlight = true,  -- enable the document highlight provider
     document_symbol = true,     -- enable the document symbol provider
-    workspace_symbols = true,   -- enable the workspace symbol provider
+    workspace_symbol = true,    -- enable the workspace symbol provider
     doc_width = 0,
     fun_data_1 = { "select", "rename", "mutate", "filter" },
     fun_data_2 = { ggplot = { "aes" }, with = { "*" } },
@@ -1580,7 +1580,7 @@ Meaning of options:
 
   - `document_symbol`: Enable the document symbol provider
 
-  - `workspace_symbols`: Enable the workspace symbol provider
+  - `workspace_symbol`: Enable the workspace symbol provider
 
 Note: The definition and references providers also recognize symbols defined
 in `{targets}` pipelines. Target-defining calls (e.g., `tar_target()`,

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -29,7 +29,7 @@ local hooks = require("r.hooks")
 ---@field document_symbol? boolean
 ---
 ---Enable the workspace symbol provider
----@field workspace_symbols? boolean
+---@field workspace_symbol? boolean
 ---
 ---Enable the document highlight provider
 ---@field document_highlight? boolean
@@ -506,7 +506,7 @@ local config = {
         references = true,
         implementation = true,
         document_symbol = true,
-        workspace_symbols = true,
+        workspace_symbol = true,
         document_highlight = true,
         doc_width = 0,
         fun_data_1 = { "select", "rename", "mutate", "filter" },

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -28,6 +28,9 @@ local hooks = require("r.hooks")
 ---Enable the document symbol provider
 ---@field document_symbol? boolean
 ---
+---Enable the workspace symbol provider
+---@field workspace_symbols? boolean
+---
 ---Enable the document highlight provider
 ---@field document_highlight? boolean
 ---
@@ -503,6 +506,7 @@ local config = {
         references = true,
         implementation = true,
         document_symbol = true,
+        workspace_symbols = true,
         document_highlight = true,
         doc_width = 0,
         fun_data_1 = { "select", "rename", "mutate", "filter" },
@@ -607,9 +611,7 @@ local config = {
             stop_types = { "program", "braced_expression" },
             dedent = false,
             wrap_inline = function(code) return code end,
-            wrap_file = function(filepath)
-                return 'Rnvim.source("' .. filepath .. '")'
-            end,
+            wrap_file = function(filepath) return 'Rnvim.source("' .. filepath .. '")' end,
         },
         python = {
             aliases = { "pyodide" },

--- a/lua/r/server.lua
+++ b/lua/r/server.lua
@@ -131,6 +131,9 @@ local start_rnvimserver = function()
     if not config.r_ls.document_symbol then
         table.insert(disable_parts, "documentSymbol")
     end
+    if not config.r_ls.workspace_symbols then
+        table.insert(disable_parts, "workspaceSymbol")
+    end
 
     local disable = table.concat(disable_parts)
     rns_env.R_LS_DISABLE = disable

--- a/lua/r/server.lua
+++ b/lua/r/server.lua
@@ -131,7 +131,7 @@ local start_rnvimserver = function()
     if not config.r_ls.document_symbol then
         table.insert(disable_parts, "documentSymbol")
     end
-    if not config.r_ls.workspace_symbols then
+    if not config.r_ls.workspace_symbol then
         table.insert(disable_parts, "workspaceSymbol")
     end
 


### PR DESCRIPTION
Forgot to add the option to op in/out of the workspace symbols as we did for the other implemented LSP features.