### PR TITLE
fix(edit.lua): ensure proper termination of external terminal sessions

### DIFF
--- a/lua/r/edit.lua
+++ b/lua/r/edit.lua
@@ -130,13 +130,6 @@ M.vim_leave = function()
         if vim.g.R_Nvim_status == 7 or vim.g.R_nvim_auto_quit_pending then
             vim.g.R_nvim_auto_quit_pending = nil
             require("r.send").cmd('quit(save = "no")')
-        else
-            require("r.run").quit_R("nosave")
-            local i = 30
-            while i > 0 and vim.g.R_Nvim_status == 7 do
-                vim.wait(100)
-                i = i - 1
-            end
         end
     end
 

--- a/lua/r/edit.lua
+++ b/lua/r/edit.lua
@@ -126,12 +126,19 @@ M.add_for_deletion = function(fname)
 end
 
 M.vim_leave = function()
-    if vim.g.R_Nvim_status == 7 and config.auto_quit then
-        require("r.run").quit_R("nosave")
-        local i = 30
-        while i > 0 and vim.g.R_Nvim_status == 7 do
-            vim.wait(100)
-            i = i - 1
+    local r_ready = vim.g.R_Nvim_status == 7
+    local auto_quit_pending = vim.g.R_nvim_auto_quit_pending
+    if (r_ready or auto_quit_pending) and config.auto_quit then
+        vim.g.R_nvim_auto_quit_pending = nil
+        if config.external_term ~= "" then
+            require("r.send").cmd('quit(save = "no")')
+        else
+            require("r.run").quit_R("nosave")
+            local i = 30
+            while i > 0 and vim.g.R_Nvim_status == 7 do
+                vim.wait(100)
+                i = i - 1
+            end
         end
     end
 

--- a/lua/r/edit.lua
+++ b/lua/r/edit.lua
@@ -126,11 +126,9 @@ M.add_for_deletion = function(fname)
 end
 
 M.vim_leave = function()
-    local r_ready = vim.g.R_Nvim_status == 7
-    local auto_quit_pending = vim.g.R_nvim_auto_quit_pending
-    if (r_ready or auto_quit_pending) and config.auto_quit then
-        vim.g.R_nvim_auto_quit_pending = nil
-        if config.external_term ~= "" then
+    if config.auto_quit then
+        if vim.g.R_Nvim_status == 7 or vim.g.R_nvim_auto_quit_pending then
+            vim.g.R_nvim_auto_quit_pending = nil
             require("r.send").cmd('quit(save = "no")')
         else
             require("r.run").quit_R("nosave")

--- a/lua/r/lsp/init.lua
+++ b/lua/r/lsp/init.lua
@@ -758,6 +758,11 @@ end
 ---@param signal integer Number describing the signal used to terminate (if any)
 ---@param client integer Client handle
 local function on_exit(code, signal, client)
+    local cfg = require("r.config").get_config()
+    if vim.g.R_Nvim_status == 7 and cfg.auto_quit and cfg.external_term ~= "" then
+        vim.g.R_nvim_auto_quit_pending = true
+    end
+
     vim.g.R_Nvim_status = 1
     if code == 0 then return end
     local msg = string.format("r_ls exit (%d, %d, %d)", code, signal, client)

--- a/lua/r/lsp/init.lua
+++ b/lua/r/lsp/init.lua
@@ -759,7 +759,7 @@ end
 ---@param client integer Client handle
 local function on_exit(code, signal, client)
     local cfg = require("r.config").get_config()
-    if vim.g.R_Nvim_status == 7 and cfg.auto_quit and cfg.external_term ~= "" then
+    if vim.g.R_Nvim_status == 7 and cfg.auto_quit then
         vim.g.R_nvim_auto_quit_pending = true
     end
 


### PR DESCRIPTION
I often have an issue when using `:wq`. I am getting this message in my terminal which do not close automatically 50% of the time:

```
R 4.5.2 ❯ [I] Connection with R.nvim was lost
```

I have used this fix for a while and I am not getting this terminal closing issue anymore:

- When closing Neovim with `auto_quit = true` and an external terminal (kitty, tmux, etc.), R often fails to quit because the `quit()` command sent as terminal text races with rnvimserver shutdown.
- Send `q('no')` via the nvimcom TCP channel first, which is processed directly by R's idle handler and bypasses the terminal frontend's input pipeline
