### PR TITLE
fix(nvimcom): fix single-column data.frame crash in nvim_viewobj

### DIFF
--- a/nvimcom/R/misc.R
+++ b/nvimcom/R/misc.R
@@ -114,7 +114,7 @@ nvim_viewobj <- function(
             nrows <- ceiling(10000 / ncol(o))
         }
         if (nrows != 0 && nrows < nrow(o)) {
-            o <- o[1:nrows, ]
+            o <- o[seq_len(nrows), , drop = FALSE]
         }
         if (!is.null(R_df_viewer)) {
             cmd <- gsub("'", "\x13", R_df_viewer)


### PR DESCRIPTION
`[.data.frame` has `drop = if (missing(i)) TRUE else length(cols) == 1` as default, not `drop = FALSE`. This means single-column data.frames are silently dropped to bare vectors when subsetted as `o[1:nrows, ]`.

Fix by explicitly passing `drop = FALSE`.
Fixes #551 