### PR TITLE
feat(lsp): add pipe chain column resolution for tidyverse data-masking

### DIFF
--- a/lua/r/lsp/definition.lua
+++ b/lua/r/lsp/definition.lua
@@ -137,6 +137,18 @@ function M.goto_definition(req_id, line, col, bufnr)
         return
     end
 
+    -- 1.5. Try pipe chain column resolution (tidyverse data-masking)
+    local pipe = require("r.lsp.pipe")
+    local pipe_match = pipe.resolve_column(bufnr, row, col, symbol)
+    if pipe_match then
+        utils.send_response("D", req_id, {
+            uri = "file://" .. pipe_match.file,
+            line = pipe_match.line,
+            col = pipe_match.col,
+        })
+        return
+    end
+
     -- 2. Check workspace index for other files (using centralized workspace.lua)
     local workspace_locations = workspace.get_definitions(symbol)
     if #workspace_locations > 0 then

--- a/lua/r/lsp/highlight.lua
+++ b/lua/r/lsp/highlight.lua
@@ -42,6 +42,27 @@ function M.document_highlight(req_id, line, col, bufnr)
     local current_scope = scope.get_scope_at_position(bufnr, line, col)
     local target_definition = current_scope and scope.resolve_symbol(word, current_scope)
 
+    -- If scope resolution fails, try pipe chain column resolution
+    if not target_definition then
+        local pipe = require("r.lsp.pipe")
+        local pipe_locs = pipe.find_locations(bufnr, line, col, word)
+        if pipe_locs and #pipe_locs > 0 then
+            local highlights = {}
+            for _, loc in ipairs(pipe_locs) do
+                local node = ast.node_at_position(bufnr, loc.line, loc.col)
+                table.insert(highlights, {
+                    range = {
+                        start = { line = loc.line, character = loc.col },
+                        ["end"] = { line = loc.line, character = loc.end_col },
+                    },
+                    kind = node and highlight_kind(node, bufnr) or 2,
+                })
+            end
+            utils.send_response("L", req_id, { highlights = highlights })
+            return
+        end
+    end
+
     local query = queries.get("references")
     local _, root = ast.get_parser_and_root(bufnr)
     if not query or not root then

--- a/lua/r/lsp/pipe.lua
+++ b/lua/r/lsp/pipe.lua
@@ -1,0 +1,227 @@
+--- Pipe chain column resolution for R.nvim LSP
+--- Handles tidyverse data-masking semantics where named arguments
+--- in functions like mutate() define columns accessible in subsequent
+--- pipe steps (|> and %>%).
+---@module 'r.lsp.pipe'
+
+local M = {}
+
+local ast = require("r.lsp.ast")
+
+--- Functions whose named arguments create columns (data-masking verbs)
+---@type table<string, boolean>
+local column_defining_fns = {
+    mutate = true,
+    transmute = true,
+    summarize = true,
+    summarise = true,
+    reframe = true,
+    rename = true,
+    count = true,
+    add_count = true,
+}
+
+--- Check if a binary_operator node is a pipe operator (|> or %>%)
+---@param node TSNode
+---@param bufnr integer
+---@return boolean
+local function is_pipe_operator(node, bufnr)
+    if node:type() ~= "binary_operator" then return false end
+    local op = node:field("operator")[1]
+    if not op then return false end
+    local text = vim.treesitter.get_node_text(op, bufnr)
+    return text == "|>" or text == "%>%"
+end
+
+--- Check if an identifier node is the name field of a column-defining argument
+--- (e.g. `dir` in `mutate(dir = dirname(path))`)
+---@param node TSNode identifier node
+---@param bufnr integer
+---@return boolean
+local function is_column_definition(node, bufnr)
+    local arg_node = node:parent()
+    if not arg_node or arg_node:type() ~= "argument" then return false end
+
+    local name_nodes = arg_node:field("name")
+    if #name_nodes == 0 or name_nodes[1]:id() ~= node:id() then return false end
+
+    -- Walk up: argument -> arguments -> call
+    local args_node = arg_node:parent()
+    local call_node = args_node and args_node:parent()
+    if not call_node or call_node:type() ~= "call" then return false end
+
+    local fn = call_node:field("function")[1]
+    if not fn then return false end
+    local fn_name = vim.treesitter.get_node_text(fn, bufnr)
+    return column_defining_fns[fn_name] == true
+end
+
+--- Check if an identifier is a non-column argument name
+--- (e.g. `glob` in `dir_ls(glob = "*.png")`)
+---@param node TSNode identifier node
+---@param bufnr integer
+---@return boolean
+local function is_regular_argument_name(node, bufnr)
+    local arg_node = node:parent()
+    if not arg_node or arg_node:type() ~= "argument" then return false end
+
+    local name_nodes = arg_node:field("name")
+    if #name_nodes == 0 or name_nodes[1]:id() ~= node:id() then return false end
+
+    return not is_column_definition(node, bufnr)
+end
+
+--- Check if an identifier is a function name position
+--- (e.g. `count` in `count(category)`)
+---@param node TSNode identifier node
+---@return boolean
+local function is_function_name(node)
+    local parent = node:parent()
+    if not parent or parent:type() ~= "call" then return false end
+    local fn_nodes = parent:field("function")
+    return #fn_nodes > 0 and fn_nodes[1]:id() == node:id()
+end
+
+--- Walk up from a position to find the root of the enclosing pipe chain.
+--- Stops at the first non-pipe ancestor after finding a pipe, so nested
+--- pipe chains (e.g. inside map()) are handled correctly.
+---@param bufnr integer Buffer number
+---@param row integer 0-indexed row
+---@param col integer 0-indexed column
+---@return TSNode? pipe_root The root binary_operator of the pipe chain
+function M.get_pipe_root(bufnr, row, col)
+    local node = ast.node_at_position(bufnr, row, col)
+    if not node then return nil end
+
+    local pipe_root = nil
+    local current = node
+
+    while current do
+        if is_pipe_operator(current, bufnr) then
+            pipe_root = current
+        elseif pipe_root then
+            break
+        end
+        current = current:parent()
+    end
+
+    return pipe_root
+end
+
+--- Collect the set of column names defined in a pipe chain
+---@param bufnr integer Buffer number
+---@param pipe_root TSNode Root of pipe chain
+---@return table<string, boolean> Set of column names
+function M.collect_column_names(bufnr, pipe_root)
+    local names = {}
+
+    local function walk(node)
+        if node:type() == "identifier" and is_column_definition(node, bufnr) then
+            local text = vim.treesitter.get_node_text(node, bufnr)
+            names[text] = true
+        end
+        for child in node:iter_children() do
+            if child:named() then walk(child) end
+        end
+    end
+
+    walk(pipe_root)
+    return names
+end
+
+--- Find all occurrences of a symbol within a pipe chain.
+--- Includes column-defining argument names but excludes regular argument
+--- names and function name positions.
+---@param bufnr integer Buffer number
+---@param pipe_root TSNode Root of pipe chain
+---@param symbol string Symbol to search for
+---@return table[] List of {file, line, col, end_col}
+function M.find_all_occurrences(bufnr, pipe_root, symbol)
+    local file = vim.api.nvim_buf_get_name(bufnr)
+    local refs = {}
+
+    local function walk(node)
+        if node:type() == "identifier" then
+            local text = vim.treesitter.get_node_text(node, bufnr)
+            if
+                text == symbol
+                and not is_regular_argument_name(node, bufnr)
+                and not is_function_name(node)
+            then
+                local start_row, start_col = node:start()
+                local _, end_col = node:end_()
+                table.insert(refs, {
+                    file = file,
+                    line = start_row,
+                    col = start_col,
+                    end_col = end_col,
+                })
+            end
+        end
+        for child in node:iter_children() do
+            if child:named() then walk(child) end
+        end
+    end
+
+    walk(pipe_root)
+    return refs
+end
+
+--- Resolve a symbol as a pipe column definition.
+--- Returns the location of the first (earliest) column definition in the chain.
+---@param bufnr integer Buffer number
+---@param row integer 0-indexed row
+---@param col integer 0-indexed column
+---@param symbol string Symbol to resolve
+---@return {file: string, line: integer, col: integer}? Location or nil
+function M.resolve_column(bufnr, row, col, symbol)
+    local pipe_root = M.get_pipe_root(bufnr, row, col)
+    if not pipe_root then return nil end
+
+    local col_names = M.collect_column_names(bufnr, pipe_root)
+    if not col_names[symbol] then return nil end
+
+    local file = vim.api.nvim_buf_get_name(bufnr)
+    local best = nil
+
+    local function walk(node)
+        if node:type() == "identifier" and is_column_definition(node, bufnr) then
+            local text = vim.treesitter.get_node_text(node, bufnr)
+            if text == symbol then
+                local start_row, start_col = node:start()
+                if
+                    not best
+                    or start_row < best.line
+                    or (start_row == best.line and start_col < best.col)
+                then
+                    best = { file = file, line = start_row, col = start_col }
+                end
+            end
+        end
+        for child in node:iter_children() do
+            if child:named() then walk(child) end
+        end
+    end
+
+    walk(pipe_root)
+    return best
+end
+
+--- Find all locations for a symbol in a pipe chain context.
+--- Returns nil if not in a pipe chain or if the symbol is not a pipe column.
+---@param bufnr integer Buffer number
+---@param row integer 0-indexed row
+---@param col integer 0-indexed column
+---@param symbol string Symbol to search for
+---@return table[]? List of {file, line, col, end_col} or nil
+function M.find_locations(bufnr, row, col, symbol)
+    local pipe_root = M.get_pipe_root(bufnr, row, col)
+    if not pipe_root then return nil end
+
+    local col_names = M.collect_column_names(bufnr, pipe_root)
+    if not col_names[symbol] then return nil end
+
+    return M.find_all_occurrences(bufnr, pipe_root, symbol)
+end
+
+return M

--- a/lua/r/lsp/references.lua
+++ b/lua/r/lsp/references.lua
@@ -78,6 +78,17 @@ function M.find_locations(line, col, bufnr)
 
     local target_definition = scope.resolve_symbol(word, current_scope)
     if not target_definition then
+        -- Try pipe chain column resolution (tidyverse data-masking)
+        local pipe = require("r.lsp.pipe")
+        local pipe_locs = pipe.find_locations(bufnr, row, col, word)
+        if pipe_locs and #pipe_locs > 0 then
+            return {
+                locations = utils.deduplicate_locations(pipe_locs),
+                word = word,
+                resolved = true,
+            }
+        end
+
         local locs = collect_workspace_references(word, bufnr)
         return { locations = locs, word = word, resolved = false }
     end

--- a/tests/test_document_highlight_spec.lua
+++ b/tests/test_document_highlight_spec.lua
@@ -154,6 +154,47 @@ describe("LSP textDocument/documentHighlight", function()
         end)
     end)
 
+    describe("pipe chain column highlights", function()
+        it("highlights column definition and references in pipe chain", function()
+            -- dir defined by mutate(dir = a), referenced in basename(dir)
+            local content = "x |> mutate(dir = a) |> mutate(category = basename(dir))"
+            -- cursor on `dir` in basename(dir): col=52
+            local bufnr = setup_test(content, { 1, 52 })
+            if not bufnr then return end
+            highlight_module.document_highlight("req_pipe1", 0, 52, bufnr)
+            local msg = assert_highlight_response("req_pipe1")
+            -- dir definition (col=12) + dir reference (col=52) = 2
+            assert.equals(2, #msg.highlights)
+        end)
+
+        it("highlights column from its definition site", function()
+            local content = "x |> mutate(dir = a) |> filter(dir > 0)"
+            -- cursor on `dir` in mutate(dir = a): col=12
+            local bufnr = setup_test(content, { 1, 12 })
+            if not bufnr then return end
+            highlight_module.document_highlight("req_pipe2", 0, 12, bufnr)
+            local msg = assert_highlight_response("req_pipe2")
+            -- definition (col=12) + reference in filter (col=31)
+            assert.equals(2, #msg.highlights)
+        end)
+
+        it("highlights column across multiple pipe steps", function()
+            local content = table.concat({
+                "x |>",
+                "  mutate(category = a) |>",
+                "  filter(category > 0) |>",
+                "  count(category)",
+            }, "\n")
+            -- cursor on `category` in count(category): row=3, col=8
+            local bufnr = setup_test(content, { 4, 8 })
+            if not bufnr then return end
+            highlight_module.document_highlight("req_pipe3", 3, 8, bufnr)
+            local msg = assert_highlight_response("req_pipe3")
+            -- definition + 2 references = 3
+            assert.equals(3, #msg.highlights)
+        end)
+    end)
+
     describe("scope-aware filtering", function()
         it("highlights only in-scope definition when variable is shadowed", function()
             local content = [[

--- a/tests/test_goto_definition_spec.lua
+++ b/tests/test_goto_definition_spec.lua
@@ -179,6 +179,38 @@ list(
         end)
     end)
 
+    describe("pipe chain column resolution", function()
+        it("jumps to column definition in mutate from a reference", function()
+            -- dir defined by mutate(dir = a), referenced in basename(dir)
+            local content = "x |> mutate(dir = a) |> mutate(category = basename(dir))"
+            -- cursor on `dir` in basename(dir): col=52
+            setup_test(content, { 1, 52 })
+            definition_module.goto_definition("req_pipe1")
+            -- should jump to dir in mutate(dir = a) at col=12
+            assert_location_response("req_pipe1", 0, 12)
+        end)
+
+        it("jumps to column definition from count() usage", function()
+            local content = table.concat({
+                "x |>",
+                "  mutate(category = a) |>",
+                "  count(category)",
+            }, "\n")
+            -- cursor on `category` in count(category): row=2, col=8
+            setup_test(content, { 3, 8 })
+            definition_module.goto_definition("req_pipe2")
+            -- should jump to category in mutate(category = a) at row=1, col=9
+            assert_location_response("req_pipe2", 1, 9)
+        end)
+
+        it("returns null for non-column argument names", function()
+            local content = 'x |> dir_ls(glob = "*.png")'
+            setup_test(content, { 1, 12 })
+            definition_module.goto_definition("req_pipe3")
+            assert_null_response("req_pipe3")
+        end)
+    end)
+
     describe("edge cases", function()
         it("handles empty buffer", function()
             setup_test("", { 1, 0 })

--- a/tests/test_rename_spec.lua
+++ b/tests/test_rename_spec.lua
@@ -295,4 +295,89 @@ describe("LSP textDocument/rename", function()
             end
         end)
     end)
+
+    -- -------------------------------------------------------------------------
+
+    describe("pipe chain column rename", function()
+        it("renames column defined in mutate and referenced later", function()
+            -- dir is defined by mutate(dir = ...) and referenced in basename(dir)
+            local content = table.concat({
+                "dummy <- 0",
+                "x |> mutate(dir = a) |> mutate(category = basename(dir))",
+            }, "\n")
+            -- cursor on `dir` in basename(dir): row=1, col=52
+            local bufnr = setup_test(content, { 2, 52 })
+            if not bufnr then return end
+            rename_module.rename_symbol("req_pipe1", 1, 52, bufnr, "folder")
+            local msg = assert_rename_response("req_pipe1")
+            -- definition site (dir =) + reference site (basename(dir)) = 2 edits
+            assert.equals(2, count_edits(msg.changes))
+            for _, edits in pairs(msg.changes) do
+                for _, edit in ipairs(edits) do
+                    assert.equals("folder", edit.newText)
+                end
+            end
+        end)
+
+        it("renames column from its definition site (argument name)", function()
+            local content = table.concat({
+                "dummy <- 0",
+                "x |> mutate(dir = a) |> filter(dir > 0)",
+            }, "\n")
+            -- cursor on `dir` in mutate(dir = a): row=1, col=12
+            local bufnr = setup_test(content, { 2, 12 })
+            if not bufnr then return end
+            rename_module.rename_symbol("req_pipe2", 1, 12, bufnr, "folder")
+            local msg = assert_rename_response("req_pipe2")
+            -- definition site (dir =) + reference site (filter(dir > 0)) = 2 edits
+            assert.equals(2, count_edits(msg.changes))
+        end)
+
+        it("renames column across multiple pipe steps", function()
+            local content = table.concat({
+                "dummy <- 0",
+                "x |>",
+                "  mutate(category = a) |>",
+                "  filter(category > 0) |>",
+                "  count(category)",
+            }, "\n")
+            -- cursor on `category` in count(category): row=4, col=8
+            local bufnr = setup_test(content, { 5, 8 })
+            if not bufnr then return end
+            rename_module.rename_symbol("req_pipe3", 4, 8, bufnr, "group")
+            local msg = assert_rename_response("req_pipe3")
+            -- definition + 2 references = 3 edits
+            assert.equals(3, count_edits(msg.changes))
+        end)
+
+        it("does not rename regular argument names in non-mutate functions", function()
+            -- `glob` in dir_ls(glob = ...) should not be treated as a column
+            local content = table.concat({
+                "dummy <- 0",
+                'x |> dir_ls(glob = "*.png") |> mutate(y = 1)',
+            }, "\n")
+            local bufnr = setup_test(content, { 2, 12 })
+            if not bufnr then return end
+            rename_module.rename_symbol("req_pipe4", 1, 12, bufnr, "pattern")
+            -- glob is not a pipe column, so rename falls through to workspace
+            -- (which returns empty) → null response
+            assert_null_response("req_pipe4")
+        end)
+
+        it(
+            "renames column referenced in across() back to its mutate definition",
+            function()
+                local content = table.concat({
+                    "dummy <- 0",
+                    "x |> mutate(a = 1, b = 2) |> across(c(a, b), ~ .x + 1)",
+                }, "\n")
+                local bufnr = setup_test(content, { 2, 39 })
+                if not bufnr then return end
+                rename_module.rename_symbol("req_pipe5", 1, 38, bufnr, "alpha")
+                -- cursor on `a` in across(c(a, b)) → renames definition in mutate(a =) too
+                local msg = assert_rename_response("req_pipe5")
+                assert.equals(2, count_edits(msg.changes))
+            end
+        )
+    end)
 end)


### PR DESCRIPTION
Introduce a new module `pipe.lua` to handle tidyverse data-masking semantics in R.nvim LSP. This allows for resolving column definitions in pipe chains, enhancing the goto definition and document highlight features.

<img width="995" height="288" alt="Peek 2026-04-22 14-38" src="https://github.com/user-attachments/assets/75059ab3-bdbf-4fbe-a99c-84da63854c6c" />
