### PR TITLE
feat(r.lua): fix pipe indentation within R functions

### DIFF
--- a/after/ftplugin/r.lua
+++ b/after/ftplugin/r.lua
@@ -1,0 +1,9 @@
+-- Override indentexpr to fix trailing-pipe/ggplot2 + indentation.
+-- vim.schedule defers until after nvim-treesitter's FileType autocmd runs,
+-- so our setting wins the race.
+vim.schedule(function()
+    if vim.bo.filetype == "r" then
+        vim.bo.indentexpr = "v:lua.require'r.indent'.get_indent(v:lnum)"
+    end
+end)
+

--- a/lua/r/indent.lua
+++ b/lua/r/indent.lua
@@ -1,0 +1,104 @@
+local M = {}
+
+local PIPE_OPS = { ["|>"] = true, ["%>%"] = true, ["+"] = true }
+
+local function is_pipe_op(bufnr, op_nodes)
+    if not op_nodes or not op_nodes[1] then return false end
+    return PIPE_OPS[vim.treesitter.get_node_text(op_nodes[1], bufnr)] == true
+end
+
+---@param bufnr integer
+---@param row integer 1-indexed line number of the previous (pipe) line
+---@return integer?
+local function pipe_continuation_indent(bufnr, row)
+    local _, root = require("r.lsp.ast").get_parser_and_root(bufnr)
+    if not root then return nil end
+
+    local line = vim.api.nvim_buf_get_lines(bufnr, row - 1, row, false)[1] or ""
+    local search_col = math.max(0, #line:gsub("%s+$", "") - 1)
+
+    local node = root:descendant_for_range(row - 1, search_col, row - 1, search_col)
+    if not node then return nil end
+
+    local pipe_root = nil
+    local current = node
+    while current do
+        if current:type() == "binary_operator" then
+            if is_pipe_op(bufnr, current:field("operator")) then
+                pipe_root = current
+            elseif pipe_root then
+                break
+            end
+        elseif pipe_root then
+            break
+        else
+            -- treesitter error-recovery: trailing |> becomes a direct child of an
+            -- ERROR node rather than a binary_operator RHS, so scan siblings before it.
+            local node_id = node:id()
+            local last_named_sibling = nil
+            for child in current:iter_children() do
+                if child:id() == node_id then break end
+                if
+                    child:type() == "binary_operator"
+                    and is_pipe_op(bufnr, child:field("operator"))
+                then
+                    pipe_root = child
+                end
+                if child:named() then last_named_sibling = child end
+            end
+            if pipe_root then break end
+            -- First step of chain: anchor on the identifier/call before |>.
+            if last_named_sibling then
+                local _, col = last_named_sibling:start()
+                return col + vim.fn.shiftwidth()
+            end
+        end
+        current = current:parent()
+    end
+
+    if pipe_root then
+        local _, col = pipe_root:start()
+        return col + vim.fn.shiftwidth()
+    end
+    return nil
+end
+
+---@param lnum integer 1-indexed target line
+---@return integer indent in columns, or -1 to fall back to autoindent
+function M.get_indent(lnum)
+    local bufnr = vim.api.nvim_get_current_buf()
+    local line = vim.api.nvim_buf_get_lines(bufnr, lnum - 1, lnum, false)[1] or ""
+
+    if line:match("^%s*$") then
+        local prev_lnum = vim.fn.prevnonblank(lnum - 1)
+        if prev_lnum > 0 then
+            local prev_line = vim.api.nvim_buf_get_lines(
+                bufnr,
+                prev_lnum - 1,
+                prev_lnum,
+                false
+            )[1] or ""
+            if
+                prev_line:match("|>%s*$")
+                or prev_line:match("%%>%%%s*$")
+                or prev_line:match("%+%s*$")
+            then
+                local indent = pipe_continuation_indent(bufnr, prev_lnum)
+                if indent then return indent end
+            end
+        end
+    end
+
+    -- fall back to nvim-treesitter (try both old and new API)
+    local ok, ts = pcall(require, "nvim-treesitter")
+    if ok and ts.indentexpr then
+        vim.v.lnum = lnum
+        return vim.fn.eval("v:lua.require'nvim-treesitter'.indentexpr()")
+    end
+    local ok2, ts_indent = pcall(require, "nvim-treesitter.indent")
+    if ok2 then return ts_indent.get_indent(lnum) end
+    return -1
+end
+
+return M
+


### PR DESCRIPTION
This PR makes sure that new lines are correctly indented within R functions for both pipe `|>` and `+` end lines.

<img width="1226" height="449" alt="Peek 2026-04-24 08-36" src="https://github.com/user-attachments/assets/bde67004-1bc5-418a-9226-4e5fae2430e2" />
