### PR TITLE
optionally suppress "building autocompletion for <package>" messages

### DIFF
--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -473,6 +473,13 @@ trigger the completion after the double colon).
 For both `library()` and `require()`, when completing the first argument, the
 popup list shows the names of installed packages.
 
+At startup, R.nvim emits messages about the packages for which completion 
+lists are built. To suppress these messages, add the following to your 
+~/.Rprofile:
+
+>r
+   options(nvimcom.build_messages = FALSE)
+<
 
 ------------------------------------------------------------------------------
 4.3.1. Quarto YAML completion                          *R.nvim-quarto-completion*

--- a/lua/r/server.lua
+++ b/lua/r/server.lua
@@ -193,7 +193,6 @@ local init_exit = function(_, data, _)
 end
 
 local build_objls_exit = function()
-    vim.schedule(function() vim.api.nvim_echo({ { " " } }, false, {}) end)
     edit.add_to_debug_info(
         "stderr of last completion data building",
         table.concat(o_err, "\n")

--- a/lua/r/server.lua
+++ b/lua/r/server.lua
@@ -11,6 +11,7 @@ local rhelp_list = {}
 local lob = {}
 local new_libs_in_rns = ""
 local building_objls = false
+local clear_status_line = false
 
 local M = {}
 
@@ -70,6 +71,7 @@ local init_stdout = function(_, data, _)
             elseif c:find("^ECHO: ") then
                 local msg = c:sub(7)
                 vim.schedule(function() vim.api.nvim_echo({ { msg } }, false, {}) end)
+                clear_status_line = true
             elseif c:find("^INFO: ") then
                 local info = vim.fn.split(c:sub(7), "=")
                 if #info == 3 then
@@ -193,9 +195,7 @@ local init_exit = function(_, data, _)
 end
 
 local build_objls_exit = function()
-    local ui2 = package.loaded["vim._core.ui2"]
-    local is_ui2_msg = ui2 and ui2.cfg and ui2.cfg.msg and ui2.cfg.msg.target == "msg"
-    if not is_ui2_msg then
+    if clear_status_line then
         vim.schedule(function() vim.api.nvim_echo({ { " " } }, false, {}) end)
     end
     edit.add_to_debug_info(

--- a/lua/r/server.lua
+++ b/lua/r/server.lua
@@ -193,6 +193,11 @@ local init_exit = function(_, data, _)
 end
 
 local build_objls_exit = function()
+    local ui2 = package.loaded["vim._core.ui2"]
+    local is_ui2_msg = ui2 and ui2.cfg and ui2.cfg.msg and ui2.cfg.msg.target == "msg"
+    if not is_ui2_msg then
+        vim.schedule(function() vim.api.nvim_echo({ { " " } }, false, {}) end)
+    end
     edit.add_to_debug_info(
         "stderr of last completion data building",
         table.concat(o_err, "\n")

--- a/nvimcom/R/bol.R
+++ b/nvimcom/R/bol.R
@@ -667,9 +667,9 @@ nvim.build.cmplls <- function() {
         p <- b$pkg[i]
         pvi <- b$ivrs[i]
         msg <- paste0("ECHO: Building completion list for \"", p, "\"\x14\n")
-        if (isTRUE(getOption("nvimcom.build_messages", TRUE))) {                    
-          cat(msg)                                                                  
-        }                                                                           
+        if (isTRUE(getOption("nvimcom.build_messages", TRUE))) {
+            cat(msg)
+        }
         flush(stdout())
         t1 <- Sys.time()
         nvim.bol(paste0(bdir, "/objls_", p, "_", pvi), p)

--- a/nvimcom/R/bol.R
+++ b/nvimcom/R/bol.R
@@ -666,11 +666,11 @@ nvim.build.cmplls <- function() {
     process_row <- function(i) {
         p <- b$pkg[i]
         pvi <- b$ivrs[i]
-        msg <- paste0("ECHO: Building completion list for \"", p, "\"\x14\n")
         if (isTRUE(getOption("nvimcom.build_messages", TRUE))) {
+            msg <- paste0("ECHO: Building completion list for \"", p, "\"\x14\n")
             cat(msg)
+            flush(stdout())
         }
-        flush(stdout())
         t1 <- Sys.time()
         nvim.bol(paste0(bdir, "/objls_", p, "_", pvi), p)
         t2 <- Sys.time()

--- a/nvimcom/R/bol.R
+++ b/nvimcom/R/bol.R
@@ -666,9 +666,10 @@ nvim.build.cmplls <- function() {
     process_row <- function(i) {
         p <- b$pkg[i]
         pvi <- b$ivrs[i]
-
         msg <- paste0("ECHO: Building completion list for \"", p, "\"\x14\n")
-        cat(msg)
+        if (isTRUE(getOption("nvimcom.build_messages", TRUE))) {                    
+          cat(msg)                                                                  
+        }                                                                           
         flush(stdout())
         t1 <- Sys.time()
         nvim.bol(paste0(bdir, "/objls_", p, "_", pvi), p)


### PR DESCRIPTION
This PR introduces the option to suppress messages about building autocompletion for packages on startup.

In my case, I have some messages fired with autocmds when I e.g. load a neovim session. Thus,  I would like to suppress those other messages that get on the way.

The behaviour can be controlled with an option in .Rprofile

options(nvimcom.build_messages = FALSE) # supresses messages

If not set, or set to TRUE, messages are shown