### PR TITLE
fix: make nvim-treesitter optional (fixes #558)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,31 +116,9 @@ sources simultaneously is not advised.
 
 ### Tree-sitter
 
-Tree-sitter is required to enable much of the functionality of R.nvim. Note
-that nvim-treesitter has been completely rewritten on
-the [main branch](https://github.com/nvim-treesitter/nvim-treesitter/tree/main)
-and the configuration used in
-the [master branch](https://github.com/nvim-treesitter/nvim-treesitter/tree/master)
-is not compatible with the new version. In the example below, we provide
-minimal configurations for both branches. Please choose the one that matches
-your installation.
+The following Tree-sitter parsers are required: `r`, `markdown`, `markdown_inline`, `rnoweb`, `yaml`, `latex`, and `csv`. They can be installed with any Tree-sitter parser manager, such as [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) or [tree-sitter-manager.nvim](https://github.com/romus204/tree-sitter-manager.nvim).
 
-If you are using [nvim-treesitter master branch](https://github.com/nvim-treesitter/nvim-treesitter/tree/master):
-
-```lua
-{
-    "nvim-treesitter/nvim-treesitter",
-    build = ":TSUpdate",
-    config = function ()
-        require("nvim-treesitter.configs").setup({
-            ensure_installed = { "markdown", "markdown_inline", "r", "rnoweb", "yaml", "latex", "csv" },
-            highlight = { enable = true },
-        })
-    end
-},
-```
-
-If you are using [nvim-treesitter main branch](https://github.com/nvim-treesitter/nvim-treesitter/tree/main):
+Example configuration using nvim-treesitter:
 
 ```lua
 {
@@ -268,8 +246,7 @@ firm commitment to backwards compatibility.
   components concatenated using either `"here::here"` (the default),
   `"here"`, `"file.path"`, `"fs::path"`, or `"path"`, depending on how
   `path_split_fun` is set. Requires
-  [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) to be
-  installed).
+  tree-sitter parsers to be installed.
 
 - `<LocalLeader>,` inserts a pipe operator (`|>`).
 

--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -91,10 +91,13 @@ Main dependencies:
       https://github.com/neovim/neovim/releases
       See also: https://github.com/neovim/neovim/wiki/Installing-Neovim
 
-   nvim-treesitter:
+   Tree-sitter parsers:
+      Parsers for `r`, `markdown`, `markdown_inline`, `rnoweb`, `yaml`,
+      `latex`, and `csv` must be installed. You can install them using any
+      tree-sitter parser manager (e.g. the `nvim-treesitter` or
+      `tree-sitter-manager` plugins) or manually.
       https://github.com/nvim-treesitter/nvim-treesitter
-      You have to enable highlighting by tree-sitter and install parsers for
-      `r`, `markdown`, `markdown_inline`, `rnoweb`, `yaml`, `latex`, and `csv`.
+      https://github.com/romus204/tree-sitter-manager.nvim
 
    R >= 4.0.0:
       http://www.r-project.org/

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -1309,27 +1309,20 @@ M.check_health = function()
         end
         return false
     end
-    local has_treesitter, _ = pcall(require, "nvim-treesitter")
-    if not has_treesitter then
+
+    local parsers = vim.api.nvim_get_runtime_file(
+        "parser" .. (config.is_windows and "\\" or "/") .. "*.*",
+        true
+    )
+    if
+        not has_parser("r", parsers)
+        or not has_parser("markdown", parsers)
+        or not has_parser("rnoweb", parsers)
+        or not has_parser("yaml", parsers)
+    then
         swarn(
-            'R.nvim requires nvim-treesitter. Please install it and the parsers for "r", "markdown", "rnoweb", and "yaml".'
+            'R.nvim requires treesitter parsers for "r", "markdown", "rnoweb", and "yaml". Please, install them.'
         )
-    else
-        -- Check if required treesitter parsers are available
-        local parsers = vim.api.nvim_get_runtime_file(
-            "parser" .. (config.is_windows and "\\" or "/") .. "*.*",
-            true
-        )
-        if
-            not has_parser("r", parsers)
-            or not has_parser("markdown", parsers)
-            or not has_parser("rnoweb", parsers)
-            or not has_parser("yaml", parsers)
-        then
-            swarn(
-                'R.nvim requires treesitter parsers for "r", "markdown", "rnoweb", and "yaml". Please, install them.'
-            )
-        end
     end
 
     if #smsgs > 0 then

--- a/lua/r/health.lua
+++ b/lua/r/health.lua
@@ -2,17 +2,11 @@
 
 local M = {}
 
-local ts_available, treesitter_parsers = pcall(require, "nvim-treesitter.parsers")
-
 --- Checks if a parser is available or not
 ---@param parser_name string
 ---@return boolean
 local function parser_installed(parser_name)
-    return (
-        ts_available
-        and treesitter_parsers.has_parser
-        and treesitter_parsers.has_parser(parser_name)
-    ) or pcall(vim.treesitter.query.get, parser_name, "highlights")
+    return pcall(vim.treesitter.language.add, parser_name)
 end
 
 M.check = function()
@@ -42,14 +36,6 @@ M.check = function()
         vim.health.error("Please, uninstall Vim-R before using R.nvim.")
     elseif vim.fn.exists("*WaitVimComStart") ~= 0 then
         vim.health.error("Please, uninstall Vim-R-plugin before using R.nvim.")
-    end
-
-    if ts_available then
-        vim.health.ok("`nvim-treesitter/nvim-treesitter` found.")
-    else
-        vim.health.warn(
-            "`nvim-treesitter/nvim-treesitter` not found. Ignore this if you manually installed the parsers."
-        )
     end
 
     if vim.fn.executable("yaml-language-server") == 1 then


### PR DESCRIPTION
- Update config, health checks, and documentation to reflect that nvim-treesitter is no longer a required dependency.
- For now, we keep nvim-treesitter for internal tests. We might change that later with the adopted successor to nvim-treesitter.