### PR TITLE
fix(nvimcom.c): ensure compatibility with R version 4.4.0 and above

### DIFF
--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -99,7 +99,7 @@ Main dependencies:
       https://github.com/nvim-treesitter/nvim-treesitter
       https://github.com/romus204/tree-sitter-manager.nvim
 
-   R >= 4.0.0:
+   R >= 4.1.0:
       http://www.r-project.org/
 
    Make and C compiler

--- a/nvimcom/DESCRIPTION
+++ b/nvimcom/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nvimcom
-Version: 0.9.93
-Date: 2026-04-24
+Version: 0.9.94
+Date: 2026-04-27
 Title: Intermediate the Communication Between R and Neovim
 Authors@R: c(
     person("Jakson", "Aquino", email = "jalvesaq@gmail.com",

--- a/nvimcom/src/nvimcom.c
+++ b/nvimcom/src/nvimcom.c
@@ -947,7 +947,12 @@ void nvimcom_task(void) {
 
             /* From R-exts: Evaluating R expressions from C */
             SEXP s, t;
+#if R_VERSION >= R_Version(4, 4, 0)
             t = s = PROTECT(Rf_allocLang(2));
+#else
+            PROTECT(t = s = Rf_allocList(2));
+            SET_TYPEOF(s, LANGSXP);
+#endif
             SETCAR(t, Rf_install("options"));
             t = CDR(t);
             SETCAR(t, Rf_ScalarInteger(columns));

--- a/nvimcom/src/nvimcom.c
+++ b/nvimcom/src/nvimcom.c
@@ -455,7 +455,7 @@ static char *nvimcom_glbnv_line(SEXP *x, const char *xname, const char *curenv,
     } else if (Rf_isFactor(*x)) {
         p = str_cat(p, "\006f\006");
 #if defined(R_VERSION) && R_VERSION >= R_Version(4, 6, 0)
-    } else if (Rf_isScalarString(*x)) {
+    } else if (Rf_isString(*x)) {
 #else
     } else if (Rf_isValidString(*x)) {
 #endif

--- a/resources/before_rns.R
+++ b/resources/before_rns.R
@@ -17,8 +17,8 @@ libp <- unique(c(
 # Check R version
 R_version <- paste0(version[c("major", "minor")], collapse = ".")
 
-if (R_version < "4.0.0") {
-    out("WARN: R.nvim requires R >= 4.0.0")
+if (R_version < "4.1.0") {
+    out("WARN: R.nvim requires R >= 4.1.0")
 }
 
 R_version <- sub("[0-9]$", "", R_version)


### PR DESCRIPTION
Add conditional compilation to use `Rf_allocLang` for R 4.4.0+. Maintain backward compatibility with older R versions using `Rf_allocList`.