### PR TITLE
fix: forward wrap_file to source_lines in send_chunk_line

### DIFF
--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -250,6 +250,7 @@ local function send_chunk_line(
     stop_fn,
     wrap_fn,
     should_dedent,
+    wrap_file_fn,
     m
 )
     local lines
@@ -259,7 +260,7 @@ local function send_chunk_line(
     local ok
 
     if #lines > 1 then
-        ok = M.source_lines(lines, nil, { dedent = should_dedent, wrap_inline = wrap_fn })
+        ok = M.source_lines(lines, nil, { dedent = should_dedent, wrap_inline = wrap_fn, wrap_file = wrap_file_fn })
     else
         local code = lines[1] or ""
         if should_dedent then code = utils.dedent(code) end
@@ -758,6 +759,7 @@ M.line = function(m)
                 make_should_stop(lang_cfg.stop_types),
                 lang_cfg.wrap_inline or function(code) return code end,
                 lang_cfg.dedent or false,
+                lang_cfg.wrap_file,
                 m
             )
         else


### PR DESCRIPTION
## Summary

- `send_chunk_line` now forwards `lang_cfg.wrap_file` to `source_lines`, fixing a regression from 751e1db (#550)
- When non-R chunk code (e.g. `{bash}`) exceeds `max_paste_lines` (default 20), `source_lines` now correctly uses the language's `wrap_file` function (e.g. `system2("bash", c(shQuote(...)))`) instead of falling back to `Rnvim.source()` which would try to source raw bash as R code

## How the bug was introduced

Commit 751e1db added multi-line handling to `send_chunk_line`, splitting into two paths:
- `#lines == 1`: inline wrap + `M.cmd()` (worked correctly)
- `#lines > 1`: `M.source_lines(lines, nil, { dedent, wrap_inline })` — **omitted `wrap_file`**

When the multi-line code exceeds `max_paste_lines`, `source_lines` writes to a temp file. Since `wrap_file` was missing, it fell through to `Rnvim.source()` instead of the language-specific file wrapper.

## Reproduction

Create a `.qmd` file with a long bash chunk (23+ lines, exceeding `max_paste_lines = 20`):

````markdown
```{bash}
if true; then
  ls > /dev/null
  ls > /dev/null
  ls > /dev/null
  ls > /dev/null
  ls > /dev/null
  ls > /dev/null
  ls > /dev/null
  ls > /dev/null
  ls > /dev/null
  ls > /dev/null
  ls > /dev/null
  ls > /dev/null
  ls > /dev/null
  ls > /dev/null
  ls > /dev/null
  ls > /dev/null
  ls > /dev/null
  ls > /dev/null
  ls > /dev/null
  ls > /dev/null
fi
```
````

Press `\l` inside the chunk. Before the fix: `Error: unexpected symbol` from R trying to parse `if true`. After the fix: bash code is correctly executed via `system2("bash", ...)`.