### PR TITLE
refactor: simplify source_lines API; add SQL chunk support

### DIFF
--- a/doc/R.nvim.txt
+++ b/doc/R.nvim.txt
@@ -2549,11 +2549,11 @@ debug. You can hold the highlighted line in the middle of the window with
 ------------------------------------------------------------------------------
 6.43. Code chunk languages                                         *chunk_langs*
 
-By default, R.nvim supports sending R, Python, and Bash code chunks from
-Quarto and R Markdown documents to R. You can add support for additional
-languages (e.g., Julia, Rust) or customise existing behaviour by adding
-entries to the `chunk_langs` table. Each entry is keyed by the canonical
-TreeSitter language name:
+By default, R.nvim supports sending R, Python, Bash, and SQL code chunks
+from Quarto and R Markdown documents to R. You can add support for
+additional languages (e.g., Julia, Rust) or customise existing behaviour by
+adding entries to the `chunk_langs` table. Each entry is keyed by the
+canonical TreeSitter language name:
 
 >lua
    chunk_langs = {
@@ -2594,6 +2594,23 @@ Fields:
                                must return a string. Used for longer code.
                                Optional: if omitted, the default R sourcing
                                mechanism is used.
+
+SQL chunks are dispatched to `DBI::dbGetQuery()` using the connection stored
+in the `nvimcom.sql.conn` R option. Before sending SQL chunks, install the
+`DBI` package and a backend driver (e.g. `RSQLite`, `RPostgres`, `odbc`),
+then set the option in your R session to a live connection object:
+>r
+   options(nvimcom.sql.conn = DBI::dbConnect(RSQLite::SQLite(), ":memory:"))
+<
+Notes:
+
+   - `DBI::dbGetQuery()` expects a single statement that returns rows.
+     Statements that do not return rows (DDL, most DML) will fail; override
+     `chunk_langs.sql.wrap_inline` / `wrap_file` to use `DBI::dbExecute()`
+     if you need that behaviour.
+   - The connection object must be available in the R session at the time
+     the chunk is sent — typically set it from a setup chunk run before any
+     SQL chunks.
 
 
 ==============================================================================

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -615,7 +615,6 @@ local config = {
             stop_types = { "program", "braced_expression" },
             dedent = false,
             wrap_inline = function(code) return code end,
-            wrap_file = function(filepath) return 'Rnvim.source("' .. filepath .. '")' end,
         },
         python = {
             aliases = { "pyodide" },

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -639,6 +639,17 @@ local config = {
                 return 'system2("bash", c(shQuote("' .. filepath .. '")))'
             end,
         },
+        sql = {
+            aliases = {},
+            stop_types = { "program" },
+            dedent = true,
+            wrap_inline = function(code)
+                return 'DBI::dbGetQuery(getOption("nvimcom.sql.conn"), r"---(' .. code .. ')---")'
+            end,
+            wrap_file = function(filepath)
+                return 'DBI::dbGetQuery(getOption("nvimcom.sql.conn"), paste(readLines("' .. filepath .. '"), collapse = "\\n"))'
+            end,
+        },
     },
 }
 

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -642,11 +642,13 @@ local config = {
             aliases = {},
             stop_types = { "program" },
             dedent = true,
+            -- suppressWarnings silences the "dbGetQuery should only be used with
+            -- SELECT" warning on DDL statements (not elegant, but pragmatic).
             wrap_inline = function(code)
-                return 'DBI::dbGetQuery(getOption("nvimcom.sql.conn"), r"---(' .. code .. ')---")'
+                return 'suppressWarnings(DBI::dbGetQuery(getOption("nvimcom.sql.conn"), r"---(' .. code .. ')---"))'
             end,
             wrap_file = function(filepath)
-                return 'DBI::dbGetQuery(getOption("nvimcom.sql.conn"), paste(readLines("' .. filepath .. '"), collapse = "\\n"))'
+                return 'suppressWarnings(DBI::dbGetQuery(getOption("nvimcom.sql.conn"), paste(readLines("' .. filepath .. '"), collapse = "\\n")))'
             end,
         },
     },

--- a/lua/r/rmd.lua
+++ b/lua/r/rmd.lua
@@ -67,7 +67,7 @@ M.send_current_chunk = function(m)
     end
 
     local codelines = chunk.codelines_from_chunks(chunks)
-    local ok = require("r.send").source_lines(codelines, "chunk")
+    local ok = require("r.send").source_lines(codelines)
 
     if ok == 0 then return end
     if m == true then M.next_chunk() end

--- a/lua/r/rnw.lua
+++ b/lua/r/rnw.lua
@@ -344,7 +344,7 @@ M.send_chunk = function(m)
     local chunkline = vim.fn.search("^<<", "bncW") + 1
     local docline = vim.fn.search("^@", "ncW") - 1
     local lines = vim.api.nvim_buf_get_lines(0, chunkline - 1, docline, true)
-    local ok = send.source_lines(lines, "chunk")
+    local ok = send.source_lines(lines)
     if ok == 0 then return end
 
     if m == true then M.next_chunk() end

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -250,6 +250,7 @@ local function send_chunk_line(
     stop_fn,
     wrap_fn,
     should_dedent,
+    wrap_file_fn,
     m
 )
     local lines
@@ -259,7 +260,7 @@ local function send_chunk_line(
     local ok
 
     if #lines > 1 then
-        ok = M.source_lines(lines, nil, { dedent = should_dedent, wrap_inline = wrap_fn })
+        ok = M.source_lines(lines, nil, { dedent = should_dedent, wrap_inline = wrap_fn, wrap_file = wrap_file_fn })
     else
         local code = lines[1] or ""
         if should_dedent then code = utils.dedent(code) end
@@ -758,6 +759,7 @@ M.line = function(m)
                 make_should_stop(lang_cfg.stop_types),
                 lang_cfg.wrap_inline or function(code) return code end,
                 lang_cfg.dedent or false,
+                lang_cfg.wrap_file,
                 m
             )
         else

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -260,7 +260,11 @@ local function send_chunk_line(
     local ok
 
     if #lines > 1 then
-        ok = M.source_lines(lines, nil, { dedent = should_dedent, wrap_inline = wrap_fn, wrap_file = wrap_file_fn })
+        ok = M.source_lines(lines, nil, {
+            dedent = should_dedent,
+            wrap_inline = wrap_fn,
+            wrap_file = wrap_file_fn,
+        }, lang)
     else
         local code = lines[1] or ""
         if should_dedent then code = utils.dedent(code) end
@@ -339,8 +343,9 @@ end
 ---@param lines string[] Lines to save and source
 ---@param what string|nil Additional operation to perform
 ---@param lang_cfg RChunkLangConfig|nil Language config for wrapping
+---@param lang string|nil Language for which the code should be wrapped
 ---@return boolean
-M.source_lines = function(lines, what, lang_cfg)
+M.source_lines = function(lines, what, lang_cfg, lang)
     require("r.edit").add_for_deletion(config.source_file)
 
     local rcmd
@@ -354,7 +359,7 @@ M.source_lines = function(lines, what, lang_cfg)
         end
     else
         vim.fn.writefile(lines, config.source_file)
-        if lang_cfg and lang_cfg.wrap_file then
+        if lang_cfg and lang_cfg.wrap_file and lang ~= "r" then
             rcmd = lang_cfg.wrap_file(config.source_file)
         elseif what then
             local sargs = string.gsub(M.get_source_args(), "^, ", "")

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -240,6 +240,7 @@ local M = {}
 ---@param stop_fn function The stop condition function
 ---@param wrap_fn function Function to wrap the code for execution
 ---@param should_dedent boolean Whether to dedent the code
+---@param wrap_file_fn function|nil Function to construct wrap_file command
 ---@param m string|nil Movement mode ("move" or nil)
 ---@return boolean Whether the command was sent successfully
 local function send_chunk_line(
@@ -250,6 +251,7 @@ local function send_chunk_line(
     stop_fn,
     wrap_fn,
     should_dedent,
+    wrap_file_fn,
     m
 )
     local lines
@@ -259,7 +261,11 @@ local function send_chunk_line(
     local ok
 
     if #lines > 1 then
-        ok = M.source_lines(lines, nil, { dedent = should_dedent, wrap_inline = wrap_fn })
+        ok = M.source_lines(lines, {
+            dedent = should_dedent,
+            wrap_inline = wrap_fn,
+            wrap_file = wrap_file_fn,
+        })
     else
         local code = lines[1] or ""
         if should_dedent then code = utils.dedent(code) end
@@ -336,10 +342,9 @@ end
 
 --- Save lines in a temporary file and send to R a command to source them.
 ---@param lines string[] Lines to save and source
----@param what string|nil Additional operation to perform
 ---@param lang_cfg RChunkLangConfig|nil Language config for wrapping
 ---@return boolean
-M.source_lines = function(lines, what, lang_cfg)
+M.source_lines = function(lines, lang_cfg)
     require("r.edit").add_for_deletion(config.source_file)
 
     local rcmd
@@ -355,9 +360,6 @@ M.source_lines = function(lines, what, lang_cfg)
         vim.fn.writefile(lines, config.source_file)
         if lang_cfg and lang_cfg.wrap_file then
             rcmd = lang_cfg.wrap_file(config.source_file)
-        elseif what then
-            local sargs = string.gsub(M.get_source_args(), "^, ", "")
-            rcmd = "Rnvim." .. what .. "(" .. sargs .. ")"
         else
             local sargs = string.gsub(M.get_source_args(), "^, ", "")
             rcmd = "Rnvim.source(" .. sargs .. ")"
@@ -380,7 +382,7 @@ M.above_lines = function()
         if string.match(line, "%S") then table.insert(filtered_lines, line) end
     end
 
-    M.source_lines(filtered_lines, nil)
+    M.source_lines(filtered_lines)
 end
 
 M.source_file = function()
@@ -414,7 +416,7 @@ M.source_file = function()
         return
     end
 
-    M.source_lines(lines, nil)
+    M.source_lines(lines)
 end
 
 -- Send the current paragraph to R. If m == 'down', move the cursor to the
@@ -424,7 +426,7 @@ M.paragraph = function(m)
     local start_line, end_line = paragraph.get_current()
 
     local lines = vim.api.nvim_buf_get_lines(0, start_line, end_line, false)
-    M.source_lines(lines, nil)
+    M.source_lines(lines)
 
     if m == true then cursor.move_next_paragraph() end
 end
@@ -488,7 +490,7 @@ M.chunks_up_to_here = function()
             end
         end
     end
-    if #lines > 0 then M.source_lines(lines, "chunk") end
+    if #lines > 0 then M.source_lines(lines) end
 end
 
 -- Send to R Console the code under a Vim motion
@@ -515,7 +517,7 @@ M.motion = function()
 
     -- Send the fetched lines to be sourced by R
     if lines and #lines > 0 then
-        M.source_lines(lines, "block")
+        M.source_lines(lines)
     else
         warn("No lines to send")
     end
@@ -616,7 +618,7 @@ M.marked_block = function(m)
 
     local lines = vim.api.nvim_buf_get_lines(0, lineA - 1, lineB, true)
 
-    local ok = M.source_lines(lines, "block", lang_cfg)
+    local ok = M.source_lines(lines, lang_cfg)
     if not ok then return end
 
     if m == true and lineB ~= last_line then
@@ -687,12 +689,8 @@ M.selection = function(m)
     end
 
     local ok
-    local canonical, lang_cfg = chunk.resolve_lang(lang)
-    if lang_cfg and canonical ~= "r" then
-        ok = M.source_lines(lines, nil, lang_cfg)
-    else
-        ok = M.source_lines(lines, "selection")
-    end
+    local _, lang_cfg = chunk.resolve_lang(lang)
+    ok = M.source_lines(lines, lang_cfg)
 
     if not ok then return end
 
@@ -758,6 +756,7 @@ M.line = function(m)
                 make_should_stop(lang_cfg.stop_types),
                 lang_cfg.wrap_inline or function(code) return code end,
                 lang_cfg.dedent or false,
+                lang_cfg.wrap_file,
                 m
             )
         else
@@ -781,7 +780,7 @@ M.line = function(m)
     lines, lnum = get_r_code_to_send(line, lnum)
 
     if #lines > 1 then
-        ok = M.source_lines(lines, nil)
+        ok = M.source_lines(lines)
     else
         if #lines == 1 then line = lines[1] end
         if config.bracketed_paste then
@@ -926,7 +925,7 @@ M.chain = function()
 
     -- If on comment and no match found, use last operator before comment
     local captured_node = sibling or (on_comment and last_sibling) or pipe_node
-    M.source_lines({ vim.treesitter.get_node_text(captured_node, bufnr) }, nil)
+    M.source_lines({ vim.treesitter.get_node_text(captured_node, bufnr) })
 end
 
 --- Retrieves R function nodes from a given buffer using TreeSitter.
@@ -1003,7 +1002,7 @@ M.funs = function(capture_all, move_down)
         end
     end
 
-    M.source_lines(lines, "function")
+    M.source_lines(lines)
 
     if move_down and target_node then
         local _, _, end_row, _ = target_node:range()

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -264,7 +264,7 @@ local function send_chunk_line(
             dedent = should_dedent,
             wrap_inline = wrap_fn,
             wrap_file = wrap_file_fn,
-        }, lang)
+        })
     else
         local code = lines[1] or ""
         if should_dedent then code = utils.dedent(code) end
@@ -343,9 +343,8 @@ end
 ---@param lines string[] Lines to save and source
 ---@param what string|nil Additional operation to perform
 ---@param lang_cfg RChunkLangConfig|nil Language config for wrapping
----@param lang string|nil Language for which the code should be wrapped
 ---@return boolean
-M.source_lines = function(lines, what, lang_cfg, lang)
+M.source_lines = function(lines, what, lang_cfg)
     require("r.edit").add_for_deletion(config.source_file)
 
     local rcmd
@@ -359,7 +358,7 @@ M.source_lines = function(lines, what, lang_cfg, lang)
         end
     else
         vim.fn.writefile(lines, config.source_file)
-        if lang_cfg and lang_cfg.wrap_file and lang ~= "r" then
+        if lang_cfg and lang_cfg.wrap_file then
             rcmd = lang_cfg.wrap_file(config.source_file)
         elseif what then
             local sargs = string.gsub(M.get_source_args(), "^, ", "")

--- a/nvimcom/NAMESPACE
+++ b/nvimcom/NAMESPACE
@@ -1,5 +1,4 @@
-export("Rnvim.source", "Rnvim.selection", "Rnvim.block", "Rnvim.paragraph",
-       "Rnvim.function", "Rnvim.chunk", "nvim.list.args", "nvim.srcdir",
+export("Rnvim.source", "nvim.list.args", "nvim.srcdir",
        "nvim.plot", "nvim.interlace.rnoweb",
        "nvim.print", "nvim.names", "etags2ctags", "nvim.interlace.rmd", "vi")
 

--- a/nvimcom/R/misc.R
+++ b/nvimcom/R/misc.R
@@ -170,53 +170,14 @@ nvim_viewobj <- function(
 #' @param ... Further arguments passed to base::source.
 #' @param print.eval See base::source.
 #' @param spaced See base::source.
-Rnvim.source <- function(..., print.eval = TRUE, spaced = FALSE) {
+Rnvim.source <- function(..., print.eval = TRUE, spaced = FALSE, local = parent.frame()) {
     base::source(
         getOption("nvimcom.source.path"),
         ...,
         print.eval = print.eval,
-        spaced = spaced
+        spaced = spaced,
+        local = local
     )
-}
-
-#' Call base::source.
-#' This function is sent to R Console when the user press `\ss`.
-#' @param ... Further arguments passed to base::source.
-#' @param local See base::source.
-Rnvim.selection <- function(..., local = parent.frame()) {
-    Rnvim.source(..., local = local)
-}
-
-#' Call base::source.
-#' This function is sent to R Console when the user press `\pp`.
-#' @param ... Further arguments passed to base::source.
-#' @param local See base::source.
-Rnvim.paragraph <- function(..., local = parent.frame()) {
-    Rnvim.source(..., local = local)
-}
-
-#' Call base::source.
-#' This function is sent to R Console when the user press `\bb`.
-#' @param ... Further arguments passed to base::source.
-#' @param local See base::source.
-Rnvim.block <- function(..., local = parent.frame()) {
-    Rnvim.source(..., local = local)
-}
-
-#' Call base::source.
-#' This function is sent to R Console when the user press `\ff`.
-#' @param ... Further arguments passed to base::source.
-#' @param local See base::source.
-Rnvim.function <- function(..., local = parent.frame()) {
-    Rnvim.source(..., local = local)
-}
-
-#' Call base::source.
-#' This function is sent to R Console when the user press `\cc`.
-#' @param ... Further arguments passed to base::source.
-#' @param local See base::source.
-Rnvim.chunk <- function(..., local = parent.frame()) {
-    Rnvim.source(..., local = local)
 }
 
 #' Source a temporary copy of an R file and, finally, delete it.

--- a/nvimcom/R/misc.R
+++ b/nvimcom/R/misc.R
@@ -167,16 +167,16 @@ nvim_viewobj <- function(
 }
 
 #' Call base::source.
+#' This function is sent to R Console by `R.nvim`.
 #' @param ... Further arguments passed to base::source.
 #' @param print.eval See base::source.
 #' @param spaced See base::source.
-Rnvim.source <- function(..., print.eval = TRUE, spaced = FALSE, local = parent.frame()) {
+Rnvim.source <- function(..., print.eval = TRUE, spaced = FALSE) {
     base::source(
         getOption("nvimcom.source.path"),
         ...,
         print.eval = print.eval,
-        spaced = spaced,
-        local = local
+        spaced = spaced
     )
 }
 

--- a/nvimcom/man/Rnvim.source.Rd
+++ b/nvimcom/man/Rnvim.source.Rd
@@ -1,22 +1,12 @@
 \name{Rnvim.source}
 \alias{Rnvim.source}
-\alias{Rnvim.selection}
-\alias{Rnvim.paragraph}
-\alias{Rnvim.function}
-\alias{Rnvim.chunk}
-\alias{Rnvim.block}
 \title{Wrapper to base::source}
 \description{
   Call base::source with the arguments \code{print.eval=TRUE} and
   \code{spaced=FALSE}.
 }
 \usage{
-  Rnvim.source(..., print.eval = TRUE, spaced = FALSE)
-  Rnvim.selection(..., local = parent.frame())
-  Rnvim.paragraph(..., local = parent.frame())
-  Rnvim.function(..., local = parent.frame())
-  Rnvim.chunk(..., local = parent.frame())
-  Rnvim.block(..., local = parent.frame())
+  Rnvim.source(..., print.eval = TRUE, spaced = FALSE, local = parent.frame())
 }
 \arguments{
   \item{print.eval}{See base::source.}

--- a/nvimcom/man/Rnvim.source.Rd
+++ b/nvimcom/man/Rnvim.source.Rd
@@ -6,11 +6,10 @@
   \code{spaced=FALSE}.
 }
 \usage{
-  Rnvim.source(..., print.eval = TRUE, spaced = FALSE, local = parent.frame())
+  Rnvim.source(..., print.eval = TRUE, spaced = FALSE)
 }
 \arguments{
   \item{print.eval}{See base::source.}
   \item{spaced}{See base::source.}
-  \item{local}{See base::source.}
   \item{...}{Further arguments passed to base::source.}
 }


### PR DESCRIPTION
Pass the `lang` parameter through to `source_lines` so it can
distinguish R from other languages.