### PR TITLE
fix: RTypst chunk detection, injection queries, and multi-language support

### DIFF
--- a/ftdetect/r.lua
+++ b/ftdetect/r.lua
@@ -14,16 +14,4 @@ vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
     pattern = "*.Rproj",
     callback = function() vim.api.nvim_set_option_value("syntax", "dcf", {}) end,
 })
-vim.filetype.add({ pattern = { [".*%.Rtyp$"] = { "typst", { priority = math.huge } } } })
-
--- This is needed because scripts.vim sees leading '#' and sets conf; override it
--- TODO: I am not sure if this is ok, but I do not find a better way at the moment
-vim.api.nvim_create_autocmd("FileType", {
-    group = "rft",
-    pattern = "conf",
-    callback = function(ev)
-        if vim.api.nvim_buf_get_name(ev.buf):match("%.Rtyp$") then
-            vim.bo[ev.buf].filetype = "typst"
-        end
-    end,
-})
+vim.filetype.add({ extension = { Rtyp = "typst" } })

--- a/ftplugin/typst_rnvim.lua
+++ b/ftplugin/typst_rnvim.lua
@@ -6,25 +6,45 @@ then
     return
 end
 
-pcall(
-    vim.treesitter.query.set,
-    "typst",
-    "injections",
-    [[
-; extends
-(raw_blck
-  (blob) @injection.content
-  (#match? @injection.content "^\\{r[,}\\s]")
-  (#offset! @injection.content 1 0 0 0)
-  (#set! injection.language "r"))
+--- Build typst injection queries dynamically from chunk_langs config.
+--- Generates one entry per canonical language and its aliases.
+local function build_typst_injections()
+    local config = require("r.config").get_config()
+    local langs = config.chunk_langs
+    if not langs then return "" end
 
-(raw_blck
-  (blob) @injection.content
-  (#match? @injection.content "^\\{python[,}\\s]")
-  (#offset! @injection.content 1 0 0 0)
-  (#set! injection.language "python"))
-]]
-)
+    local parts = { "; extends" }
+
+    for lang, lang_cfg in pairs(langs) do
+        local names = { lang }
+        if lang_cfg.aliases then
+            for _, alias in ipairs(lang_cfg.aliases) do
+                table.insert(names, alias)
+            end
+        end
+
+        for _, name in ipairs(names) do
+            local escaped = name:gsub("([^%w])", "\\%1")
+            -- Build match pattern: ^\\{name[,\\}\\s]
+            local match_pat = "^"
+                .. "\\\\" .. "{"
+                .. escaped
+                .. "[," .. "\\\\" .. "}" .. "\\\\" .. "s]"
+
+            local entry = "(raw_blck\n"
+                .. "  (blob) @injection.content\n"
+                .. '  (#match? @injection.content "' .. match_pat .. '")\n'
+                .. "  (#offset! @injection.content 1 -3 0 0)\n"
+                .. '  (#set! injection.language "' .. lang .. '"))'
+
+            table.insert(parts, entry)
+        end
+    end
+
+    return table.concat(parts, "\n\n")
+end
+
+pcall(vim.treesitter.query.set, "typst", "injections", build_typst_injections())
 
 require("r.config").real_setup()
 require("r.rmd").setup()

--- a/ftplugin/typst_rnvim.lua
+++ b/ftplugin/typst_rnvim.lua
@@ -14,14 +14,14 @@ pcall(
 ; extends
 (raw_blck
   (blob) @injection.content
-  (#match? @injection.content "^\\{r\\}")
-  (#offset! @injection.content 0 3 0 0)
+  (#match? @injection.content "^\\{r[,}\\s]")
+  (#offset! @injection.content 1 0 0 0)
   (#set! injection.language "r"))
 
 (raw_blck
   (blob) @injection.content
-  (#match? @injection.content "^\\{python\\}")
-  (#offset! @injection.content 0 8 0 0)
+  (#match? @injection.content "^\\{python[,}\\s]")
+  (#offset! @injection.content 1 0 0 0)
   (#set! injection.language "python"))
 ]]
 )

--- a/lua/r/chunk.lua
+++ b/lua/r/chunk.lua
@@ -90,7 +90,7 @@ function Chunk:get_info_string_params() return self.info_string_params end
 ---@return table
 function Chunk:get_comment_params() return self.comment_params end
 
---- Helper function to get code block from Rmd, Quarto, or RTypst document.
+--- Helper function to get code block from Rmd or Quarto document.
 --- The function is called by r_ls too.
 ---@param bufnr  integer The buffer number.
 ---@return table|nil
@@ -151,6 +151,67 @@ local get_rmd_code_chunks = function(bufnr)
 
             table.insert(code_chunks, chunk)
         end
+    end
+
+    return code_chunks
+end
+
+--- Get code chunks from an RTypst (.Rtyp) document using the typst TreeSitter parser.
+---@param bufnr integer The buffer number.
+---@return table|nil
+local get_rtypst_code_chunks = function(bufnr)
+    bufnr = bufnr or vim.api.nvim_get_current_buf()
+
+    local ok, parser = pcall(vim.treesitter.get_parser, bufnr, "typst")
+    if not ok or not parser then return nil end
+
+    local root = parser:parse()[1]:root()
+
+    local query = vim.treesitter.query.parse(
+        "typst",
+        [[
+        (raw_blck
+          (blob) @raw_blob)
+        ]]
+    )
+
+    local code_chunks = {}
+
+    for id, node, _ in query:iter_captures(root, bufnr, 0, -1) do
+        if query.captures[id] == "raw_blob" then
+            local text = vim.treesitter.get_node_text(node, bufnr)
+            -- Match chunks like {r}, {r, echo=FALSE}, {python}, etc.
+            local header_line = text:match("^(.-)\n")
+            if not header_line then goto continue end
+
+            local lang = header_line:match("^{(%a+)[,}%s]")
+                or header_line:match("^{(%a+)}")
+            if not lang then goto continue end
+
+            local start_row, _, end_row, _ = node:range()
+            -- Content is everything after the first line
+            local content_text = text:sub(#header_line + 2) -- skip \n
+
+            -- Strip trailing ``` line from content
+            content_text = content_text:gsub("\n```\n?$", "")
+
+            local info_string_params = M.parse_info_string_params(header_line)
+            local comment_params = M.parse_comment_params(text)
+
+            local c = Chunk:new(
+                content_text,
+                start_row + 1,
+                end_row,
+                info_string_params,
+                comment_params,
+                lang,
+                node:parent()
+            )
+
+            table.insert(code_chunks, c)
+        end
+
+        ::continue::
     end
 
     return code_chunks
@@ -218,6 +279,7 @@ end
 
 M.get_code_chunks = function(bufnr)
     if vim.bo.filetype == "rnoweb" then return get_rnw_code_chunks(bufnr) end
+    if vim.bo.filetype == "typst" then return get_rtypst_code_chunks(bufnr) end
     return get_rmd_code_chunks(bufnr)
 end
 

--- a/lua/r/chunk.lua
+++ b/lua/r/chunk.lua
@@ -182,36 +182,34 @@ local get_rtypst_code_chunks = function(bufnr)
             local text = vim.treesitter.get_node_text(node, bufnr)
             -- Match chunks like {r}, {r, echo=FALSE}, {python}, etc.
             local header_line = text:match("^(.-)\n")
-            if not header_line then goto continue end
+            if header_line then
+                local lang = header_line:match("^{(%a+)[,}%s]")
+                    or header_line:match("^{(%a+)}")
+                if lang then
+                    local start_row, _, end_row, _ = node:range()
+                    -- Content is everything after the first line
+                    local content_text = text:sub(#header_line + 2) -- skip \n
 
-            local lang = header_line:match("^{(%a+)[,}%s]")
-                or header_line:match("^{(%a+)}")
-            if not lang then goto continue end
+                    -- Strip trailing ``` line from content
+                    content_text = content_text:gsub("\n```\n?$", "")
 
-            local start_row, _, end_row, _ = node:range()
-            -- Content is everything after the first line
-            local content_text = text:sub(#header_line + 2) -- skip \n
+                    local info_string_params = M.parse_info_string_params(header_line)
+                    local comment_params = M.parse_comment_params(text)
 
-            -- Strip trailing ``` line from content
-            content_text = content_text:gsub("\n```\n?$", "")
+                    local c = Chunk:new(
+                        content_text,
+                        start_row + 1,
+                        end_row,
+                        info_string_params,
+                        comment_params,
+                        lang,
+                        node:parent()
+                    )
 
-            local info_string_params = M.parse_info_string_params(header_line)
-            local comment_params = M.parse_comment_params(text)
-
-            local c = Chunk:new(
-                content_text,
-                start_row + 1,
-                end_row,
-                info_string_params,
-                comment_params,
-                lang,
-                node:parent()
-            )
-
-            table.insert(code_chunks, c)
+                    table.insert(code_chunks, c)
+                end
+            end
         end
-
-        ::continue::
     end
 
     return code_chunks

--- a/lua/r/chunk.lua
+++ b/lua/r/chunk.lua
@@ -187,6 +187,9 @@ local get_rtypst_code_chunks = function(bufnr)
                     or header_line:match("^{(%a+)}")
                 if lang then
                     local start_row, _, end_row, _ = node:range()
+                    -- Use the parent raw_blck's end_row to include the closing ```
+                    -- so that the last content line isn't treated as "chunk_end".
+                    local parent_end_row = node:parent() and node:parent():range() or end_row
                     -- Content is everything after the first line
                     local content_text = text:sub(#header_line + 2) -- skip \n
 
@@ -199,7 +202,7 @@ local get_rtypst_code_chunks = function(bufnr)
                     local c = Chunk:new(
                         content_text,
                         start_row + 1,
-                        end_row,
+                        parent_end_row,
                         info_string_params,
                         comment_params,
                         lang,

--- a/lua/r/chunk.lua
+++ b/lua/r/chunk.lua
@@ -95,12 +95,10 @@ function Chunk:get_comment_params() return self.comment_params end
 ---@param bufnr  integer The buffer number.
 ---@return table|nil
 local get_rmd_code_chunks = function(bufnr)
+    local root = require("r.utils").get_root_node()
+    if not root then return nil end
+
     bufnr = bufnr or vim.api.nvim_get_current_buf()
-
-    local ok, parser = pcall(vim.treesitter.get_parser, bufnr, "markdown")
-    if not ok or not parser then return nil end
-
-    local root = parser:parse()[1]:root()
 
     local query = vim.treesitter.query.parse(
         "markdown",

--- a/lua/r/chunk.lua
+++ b/lua/r/chunk.lua
@@ -189,8 +189,6 @@ local get_rtypst_code_chunks = function(bufnr)
                     local start_row, _, end_row, _ = node:range()
                     -- Use the parent raw_blck's end_row to include the closing ```
                     -- so that the last content line isn't treated as "chunk_end".
-                    -- Use the parent raw_blck's end_row to include the closing ```
-                    -- so that the last content line isn't treated as "chunk_end".
                     -- +1 converts 0-indexed exclusive end to 1-indexed cursor row.
                     local parent_end_row
                     do

--- a/lua/r/chunk.lua
+++ b/lua/r/chunk.lua
@@ -189,7 +189,19 @@ local get_rtypst_code_chunks = function(bufnr)
                     local start_row, _, end_row, _ = node:range()
                     -- Use the parent raw_blck's end_row to include the closing ```
                     -- so that the last content line isn't treated as "chunk_end".
-                    local parent_end_row = node:parent() and node:parent():range() or end_row
+                    -- Use the parent raw_blck's end_row to include the closing ```
+                    -- so that the last content line isn't treated as "chunk_end".
+                    -- +1 converts 0-indexed exclusive end to 1-indexed cursor row.
+                    local parent_end_row
+                    do
+                        local p = node:parent()
+                        if p then
+                            local _, _, pe_row, _ = p:range()
+                            parent_end_row = pe_row + 1
+                        else
+                            parent_end_row = end_row + 1
+                        end
+                    end
                     -- Content is everything after the first line
                     local content_text = text:sub(#header_line + 2) -- skip \n
 

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -1293,6 +1293,17 @@ M.real_setup = function()
     local no_ts = { "rhelp" }
     if config.register_treesitter then
         vim.treesitter.language.register("markdown", { "quarto", "rmd" })
+        -- Register chunk_lang aliases so that tree-sitter injection resolution
+        -- maps them to their canonical parser (e.g., "webr" → "r" parser).
+        if config.chunk_langs then
+            for lang, lang_cfg in pairs(config.chunk_langs) do
+                if lang_cfg.aliases then
+                    for _, alias in ipairs(lang_cfg.aliases) do
+                        vim.treesitter.language.register(lang, alias)
+                    end
+                end
+            end
+        end
     else
         table.insert(no_ts, "quarto")
         table.insert(no_ts, "rmd")

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -1293,17 +1293,6 @@ M.real_setup = function()
     local no_ts = { "rhelp" }
     if config.register_treesitter then
         vim.treesitter.language.register("markdown", { "quarto", "rmd" })
-        -- Register chunk_lang aliases so that tree-sitter injection resolution
-        -- maps them to their canonical parser (e.g., "webr" → "r" parser).
-        if config.chunk_langs then
-            for lang, lang_cfg in pairs(config.chunk_langs) do
-                if lang_cfg.aliases then
-                    for _, alias in ipairs(lang_cfg.aliases) do
-                        vim.treesitter.language.register(lang, alias)
-                    end
-                end
-            end
-        end
     else
         table.insert(no_ts, "quarto")
         table.insert(no_ts, "rmd")

--- a/lua/r/lsp/init.lua
+++ b/lua/r/lsp/init.lua
@@ -270,6 +270,8 @@ local get_lang = function(lnum)
     local lines = vim.api.nvim_buf_get_lines(0, 0, lnum, true)
     if vim.bo.filetype == "rmd" or vim.bo.filetype == "quarto" then
         return get_quarto_lang(lines, lnum)
+    elseif vim.bo.filetype == "typst" then
+        return get_quarto_lang(lines, lnum)
     elseif vim.bo.filetype == "rnoweb" then
         return get_rnoweb_lang(lnum, lines)
     elseif vim.bo.filetype == "rhelp" then
@@ -609,7 +611,7 @@ M.signature = function(req_id)
     end
 end
 
-local r_filetypes = { r = true, rmd = true, quarto = true, rnoweb = true, rhelp = true }
+local r_filetypes = { r = true, rmd = true, quarto = true, rnoweb = true, rhelp = true, typst = true }
 
 --- Return the source R buffer for an LSP request.
 --- Prefers the bufnr passed from C (via vim.uri_to_bufnr). Falls back to

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -633,7 +633,7 @@ M.selection = function(m)
     local lang = utils.get_lang()
 
     if
-        vim.tbl_contains({ "markdown", "rmd", "quarto" }, vim.o.filetype)
+        vim.tbl_contains({ "markdown", "rmd", "quarto", "typst" }, vim.o.filetype)
         and not chunk.is_supported_lang(lang)
         and not vim.api.nvim_get_current_line():find("`r ")
     then

--- a/lua/r/utils.lua
+++ b/lua/r/utils.lua
@@ -84,8 +84,8 @@ function M.get_lang()
     if filetype == "rnoweb" then return get_rnw_lang() end
     if filetype == "rhelp" then return get_rhelp_lang() end
 
-    -- Handle quarto/rmd code blocks
-    if vim.tbl_contains({ "markdown", "rmd", "quarto" }, filetype) then
+    -- Handle quarto/rmd/typst code blocks
+    if vim.tbl_contains({ "markdown", "rmd", "quarto", "typst" }, filetype) then
         local current_chunk =
             chunk.get_current_code_chunk(vim.api.nvim_get_current_buf())
         if current_chunk and current_chunk.lang then return current_chunk:get_lang() end


### PR DESCRIPTION
## Summary

- Fix typst chunk range detection using `raw_blck` parent node's end_row, properly converting 0-indexed exclusive tree-sitter positions to 1-indexed cursor rows
- Generate typst injection queries dynamically from `chunk_langs` config, supporting all languages and their aliases (r, python, bash, sql, webr→r, pyodide→python, etc.)
- Register chunk_lang aliases via `vim.treesitter.language.register()` so injection resolution maps aliases to canonical parsers (e.g., `webr` → r parser)
- Add typst to LSP `get_lang()` dispatch and `r_filetypes` table to prevent "Index out of bounds" crash when editing Rtyp alongside Quarto files
- Simplify filetype detection to `vim.filetype.add({ extension = { Rtyp = "typst" } })` — the `pattern` approach was unreliable
- Fix injection `#offset!` to `1 -3 0 0` — blob starts at col 3 (after opening ```), so offset adjusts start to row+1 (skip info string) and col-3 (back to col 0)

## Files changed

| File | Change |
|------|--------|
| `ftdetect/r.lua` | Simplified `.Rtyp` → `typst` detection using `extension` key |
| `ftplugin/typst_rnvim.lua` | Dynamic injection query generation from `chunk_langs` |
| `lua/r/chunk.lua` | New `get_rtypst_code_chunks()` using typst tree-sitter with proper range handling |
| `lua/r/config.lua` | Register chunk_lang aliases for tree-sitter injection resolution |
| `lua/r/lsp/init.lua` | Add typst to `get_lang()` and `r_filetypes` |
| `lua/r/send.lua` | Add typst to filetype checks |
| `lua/r/utils.lua` | Add typst to code block lookup |