### PR TITLE
Enable searching home, project root, and file's directory for latexmkrc file

### DIFF
--- a/lua/r/rnw.lua
+++ b/lua/r/rnw.lua
@@ -592,14 +592,20 @@ M.set_pdf_dir = function()
     vim.b.rplugin_pdfdir = "."
 
     -- Latexmk has an option to create the PDF in a directory other than '.'
-    if config.latexcmd and (vim.fn.glob("~/.latexmkrc") ~= "") == 1 then
-        local ltxmk = vim.fn.readfile(vim.fn.expand("~/.latexmkrc"))
-        for _, line in ipairs(ltxmk) do
-            if
-                line:match('out_dir%s*=%s*"(.*)"') or line:match("out_dir%s*=%s*'(.*)'")
-            then
-                vim.b.rplugin_pdfdir = line:match('out_dir%s*=%s*"(.*)"')
-                    or line:match("out_dir%s*=%s*'(.*)'")
+    if config.latexcmd then
+        local chkdirs = { "~", ".", vim.fn.expand("%:p:h") }
+        for _, chkdir in pairs(chkdirs) do
+            if vim.fn.glob(chkdir .. "/.latexmkrc") ~= "" then
+                local ltxmk = vim.fn.readfile(vim.fn.expand(chkdir .. "/.latexmkrc"))
+                for _, line in ipairs(ltxmk) do
+                    if
+                        line:match('out_dir%s*=%s*"(.*)"')
+                        or line:match("out_dir%s*=%s*'(.*)'")
+                    then
+                        vim.b.rplugin_pdfdir = line:match('out_dir%s*=%s*"(.*)"')
+                            or line:match("out_dir%s*=%s*'(.*)'")
+                    end
+                end
             end
         end
     end

--- a/lua/r/rnw.lua
+++ b/lua/r/rnw.lua
@@ -594,17 +594,13 @@ M.set_pdf_dir = function()
     -- Latexmk has an option to create the PDF in a directory other than '.'
     if config.latexcmd then
         local chkdirs = { "~", ".", vim.fn.expand("%:p:h") }
-        for _, chkdir in pairs(chkdirs) do
+        for _, chkdir in ipairs(chkdirs) do
             if vim.fn.glob(chkdir .. "/.latexmkrc") ~= "" then
                 local ltxmk = vim.fn.readfile(vim.fn.expand(chkdir .. "/.latexmkrc"))
                 for _, line in ipairs(ltxmk) do
-                    if
-                        line:match('out_dir%s*=%s*"(.*)"')
+                    vim.b.rplugin_pdfdir = line:match('out_dir%s*=%s*"(.*)"')
                         or line:match("out_dir%s*=%s*'(.*)'")
-                    then
-                        vim.b.rplugin_pdfdir = line:match('out_dir%s*=%s*"(.*)"')
-                            or line:match("out_dir%s*=%s*'(.*)'")
-                    end
+                        or vim.b.rplugin_pdfdir
                 end
             end
         end


### PR DESCRIPTION
This change enables searching home directory, cwd (typically the project root), and then file's directory for a ".latexmkrc" file. It does this in reverse of the stated order, so that the "most local" 'out_dir' configuration stands.