### PR TITLE
Search for latexmk in more places

### DIFF
--- a/nvimcom/R/interlace.R
+++ b/nvimcom/R/interlace.R
@@ -323,7 +323,13 @@ nvim.interlace.rnoweb <- function(
     }
 
     if (!file.exists(logf)) {
-        paths <- c("~/.latexmkrc", ".latexmkrc", paste0(rnwdir, "/.latexmkrc"))
+        paths <- c(
+            paste0(rnwdir, "/.latexmkrc"),
+            ".latexmkrc",
+            "~/.latexmkrc",
+            file.path(Sys.getenv("XDG_CONFIG_HOME"), "latexmk/latexmkrc"),
+            "~/.config/latexmk/latexmkrc"
+        )
         found <- file.exists(paths)
         if (latexcmd == "latexmk" && any(found)) {
             foundlmks <- paths[found]
@@ -336,6 +342,7 @@ nvim.interlace.rnoweb <- function(
                         "/",
                         sub("\\....$", ".log", rnwf)
                     )
+                    break
                 }
             }
         } else {

--- a/nvimcom/R/interlace.R
+++ b/nvimcom/R/interlace.R
@@ -323,15 +323,20 @@ nvim.interlace.rnoweb <- function(
     }
 
     if (!file.exists(logf)) {
-        if (latexcmd == "latexmk" && file.exists("~/.latexmkrc")) {
-            lmk <- readLines("~/.latexmkrc")
-            idx <- grep("\\$out_dir\\s*=", lmk)
-            if (length(idx) == 1) {
-                logf <- paste0(
-                    sub(".*\\$out_dir\\s*=\\s*['\"](.*)['\"].*", "\\1", lmk[idx]),
-                    "/",
-                    sub("\\....$", ".log", rnwf)
-                )
+        paths <- c("~/.latexmkrc", ".latexmkrc", paste0(rnwdir, "/.latexmkrc"))
+        found <- file.exists(paths)
+        if (latexcmd == "latexmk" && any(found)) {
+            foundlmks <- paths[found]
+            for (lmkfile in foundlmks) {
+                lmk <- readLines(lmkfile)
+                idx <- grep("\\$out_dir\\s*=", lmk)
+                if (length(idx) == 1) {
+                    logf <- paste0(
+                        sub(".*\\$out_dir\\s*=\\s*['\"](.*)['\"].*", "\\1", lmk[idx]),
+                        "/",
+                        sub("\\....$", ".log", rnwf)
+                    )
+                }
             }
         } else {
             idx <- grep("-output-directory=", latexargs)


### PR DESCRIPTION
This follows up on PR #582, adding similar logic to search the home directory, cwd (typically the project root), and then file's directory for a ".latexmkrc" file to "nvimcom/R/interlace.R" (the other place where the latexmkrc file i searched for). As in the rmw.lua case, it does this in reverse of the stated order, so that the "most local" 'out_dir' configuration stands.