### PR TITLE
refactor(references.lua): move pipe chain column resolution logic before target definition check

### DIFF
--- a/lua/r/lsp/references.lua
+++ b/lua/r/lsp/references.lua
@@ -76,19 +76,18 @@ function M.find_locations(line, col, bufnr)
         return { locations = locs, word = word, resolved = false }
     end
 
+    local pipe = require("r.lsp.pipe")
+    local pipe_locs = pipe.find_locations(bufnr, row, col, word)
+    if pipe_locs and #pipe_locs > 0 then
+        return {
+            locations = utils.deduplicate_locations(pipe_locs),
+            word = word,
+            resolved = true,
+        }
+    end
+
     local target_definition = scope.resolve_symbol(word, current_scope)
     if not target_definition then
-        -- Try pipe chain column resolution (tidyverse data-masking)
-        local pipe = require("r.lsp.pipe")
-        local pipe_locs = pipe.find_locations(bufnr, row, col, word)
-        if pipe_locs and #pipe_locs > 0 then
-            return {
-                locations = utils.deduplicate_locations(pipe_locs),
-                word = word,
-                resolved = true,
-            }
-        end
-
         local locs = collect_workspace_references(word, bufnr)
         return { locations = locs, word = word, resolved = false }
     end


### PR DESCRIPTION
Small bug fix when using *renaming symbol* in a pipe expression.

```r
summarise_mtcars <- function(data = mtcars) {
  data |>
    as_tibble(rownames = "model") |>
    mutate(power_to_weight = hp / wt) |>
    summarise(
      mean_mpg = mean(mpg),
      mean_p2w = mean(power_to_weight),
      .by = cyl
    )
}
```

Place the cursor on `power_to_weight` in the `mutate()` function. Try to rename, and only the `power_to_weight` in the `summarise()` gets renamed. This PR make sure that both are renamed.