### PR TITLE
fix(config): handle Windows rnvim config path

### DIFF
--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -1289,10 +1289,13 @@ M.real_setup = function()
 
     require("r.rproj").apply_settings(config)
 
-    local rnc = vim.api.nvim_buf_get_name(0):match("(.*/).*") .. "rnvim_config.lua"
-    if vim.uv.fs_access(rnc, "R") then
-        local opts = dofile(rnc)
-        apply_user_opts(opts)
+    local bufname = vim.api.nvim_buf_get_name(0)
+    if bufname ~= "" then
+        local rnc = vim.fs.joinpath(vim.fs.dirname(bufname), "rnvim_config.lua")
+        if vim.uv.fs_access(rnc, "R") then
+            local opts = dofile(rnc)
+            apply_user_opts(opts)
+        end
     end
 
     local no_ts = { "rhelp" }


### PR DESCRIPTION
## Summary

Fix the per-buffer `rnvim_config.lua` lookup so it works with Windows buffer paths. The previous slash-only Lua pattern could return `nil` for backslash-separated paths and fail before checking whether the config file exists.

This bug was introduced in PR #515.

## Changes

- Build the config path with `vim.fs.dirname()` and `vim.fs.joinpath()` instead of a hard-coded `/` pattern.
- Guard the lookup when the current buffer has no file name.
