### PR TITLE
refactor: use builtin path functions

### DIFF
--- a/ftplugin/r_rnvim.lua
+++ b/ftplugin/r_rnvim.lua
@@ -35,7 +35,7 @@ require("r").show_R_out = function()
     routfile = vim.fn.expand("%:r") .. ".Rout"
     if vim.fn.bufloaded(routfile) == 1 then
         vim.api.nvim_command("bunload " .. routfile)
-        vim.fn.delete(routfile)
+        vim.fs.rm(routfile, { force = true })
     end
 
     -- If not silent, the user will have to type <Enter>

--- a/lua/r/browser.lua
+++ b/lua/r/browser.lua
@@ -411,9 +411,13 @@ function M.update_OB(what)
     -- Read the data from temporary files created by R
     local lines
     if wht == "GlobalEnv" then
-        lines = vim.fn.readfile(config.tmpdir .. "/globenv_" .. vim.env.RNVIM_ID)
+        lines = vim.fn.readfile(
+            vim.fs.joinpath(config.tmpdir, "globenv_" .. vim.env.RNVIM_ID)
+        )
     else
-        lines = vim.fn.readfile(config.tmpdir .. "/liblist_" .. vim.env.RNVIM_ID)
+        lines = vim.fn.readfile(
+            vim.fs.joinpath(config.tmpdir, "liblist_" .. vim.env.RNVIM_ID)
+        )
     end
     if not lines then lines = { "Error loading data" } end
 

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -1,5 +1,6 @@
 local utils = require("r.utils")
 local uv = vim.uv
+local fs = vim.fs
 local hooks = require("r.hooks")
 
 ---@class RLSConfigOpts
@@ -839,14 +840,15 @@ local set_directories = function()
     -- config.rnvim_home should be the directory where the plugin files are.
     local rndir = debug.getinfo(1, "S").source
     rndir = rndir:match("^@(.*)/lua/r/.*")
-    config.rnvim_home = rndir
+    config.rnvim_home = fs.normalize(rndir)
 
     -- config.uservimfiles must be a writable directory. It will be config.rnvim_home
     -- unless it's not writable. Then it wil be ~/.vim or ~/vimfiles.
     if vim.fn.filewritable(config.rnvim_home) == 2 then
         config.uservimfiles = config.rnvim_home
     else
-        config.uservimfiles = vim.split(vim.fn.expand("&runtimepath"), ",")[1]
+        config.uservimfiles =
+            fs.normalize(vim.split(vim.fn.expand("&runtimepath"), ",")[1])
     end
 
     -- Windows logins can include domain, e.g: 'DOMAIN\Username', need to remove
@@ -881,64 +883,61 @@ local set_directories = function()
         swarn("Could not determine user name.")
     end
 
-    if config.is_windows then
-        config.rnvim_home = utils.normalize_windows_path(config.rnvim_home)
-        config.uservimfiles = utils.normalize_windows_path(config.uservimfiles)
-    end
     vim.env.RNVIM_HOME = rndir
 
     if config.compldir ~= "" then
-        config.compldir = vim.fn.expand(config.compldir)
+        config.compldir = fs.normalize(config.compldir)
     elseif config.is_windows and vim.env.APPDATA then
-        config.compldir = vim.fn.expand(vim.env.APPDATA) .. "\\R.nvim"
+        config.compldir = fs.joinpath(vim.env.APPDATA, "R.nvim")
     elseif vim.env.XDG_CACHE_HOME then
-        config.compldir = vim.fn.expand(vim.env.XDG_CACHE_HOME) .. "/R.nvim"
-    elseif vim.fn.isdirectory(vim.fn.expand("~/.cache")) ~= 0 then
-        config.compldir = vim.fn.expand("~/.cache/R.nvim")
-    elseif vim.fn.isdirectory(vim.fn.expand("~/Library/Caches")) ~= 0 then
-        config.compldir = vim.fn.expand("~/Library/Caches/R.nvim")
+        config.compldir = fs.joinpath(fs.normalize(vim.env.XDG_CACHE_HOME), "R.nvim")
+    elseif vim.fn.isdirectory(fs.normalize("~/.cache")) ~= 0 then
+        config.compldir = fs.normalize("~/.cache/R.nvim")
+    elseif vim.fn.isdirectory(fs.normalize("~/Library/Caches")) ~= 0 then
+        config.compldir = fs.normalize("~/Library/Caches/R.nvim")
     else
-        config.compldir = config.uservimfiles .. "/R_cache/"
+        config.compldir = fs.joinpath(config.uservimfiles, "R_cache")
     end
 
     utils.ensure_directory_exists(config.compldir)
 
     -- Check if the 'config' table has the key 'tmpdir'
     if not config.tmpdir ~= "" then
+        local suffix = "R.nvim-" .. config.user_login
+        local base
         -- Set temporary directory based on the platform
         if config.is_windows then
             if vim.env.TMP and vim.fn.isdirectory(vim.env.TMP) ~= 0 then
-                config.tmpdir = vim.env.TMP .. "/R.nvim-" .. config.user_login
+                base = fs.normalize(vim.env.TMP)
             elseif vim.env.TEMP and vim.fn.isdirectory(vim.env.TEMP) ~= 0 then
-                config.tmpdir = vim.env.TEMP .. "/R.nvim-" .. config.user_login
+                base = fs.normalize(vim.env.TEMP)
             else
-                config.tmpdir = config.uservimfiles .. "/R_tmp"
+                base = config.uservimfiles
+                suffix = "R_tmp"
             end
-            config.tmpdir = utils.normalize_windows_path(config.tmpdir)
         else
             if vim.env.TMPDIR and vim.fn.isdirectory(vim.env.TMPDIR) ~= 0 then
-                if string.find(vim.env.TMPDIR, "/$") then
-                    config.tmpdir = vim.env.TMPDIR .. "R.nvim-" .. config.user_login
-                else
-                    config.tmpdir = vim.env.TMPDIR .. "/R.nvim-" .. config.user_login
-                end
+                base = fs.normalize(vim.env.TMPDIR)
             elseif vim.fn.isdirectory("/dev/shm") ~= 0 then
-                config.tmpdir = "/dev/shm/R.nvim-" .. config.user_login
+                base = "/dev/shm"
             elseif vim.fn.isdirectory("/tmp") ~= 0 then
-                config.tmpdir = "/tmp/R.nvim-" .. config.user_login
+                base = "/tmp"
             else
-                config.tmpdir = config.uservimfiles .. "/R_tmp"
+                base = config.uservimfiles
+                suffix = "R_tmp"
             end
         end
+
+        config.tmpdir = fs.joinpath(base, suffix)
     end
 
     -- Adjust options when accessing R remotely
     if config.remote_R_host ~= "" then
-        config.tmpdir = config.compldir .. "/remote/tmp"
+        config.tmpdir = fs.joinpath(config.compldir, "remote/tmp")
         if config.remote_compl_dir == "" then
             config.remote_compl_dir = config.compldir
         end
-        config.remote_tmpdir = config.remote_compl_dir .. "/tmp"
+        config.remote_tmpdir = fs.joinpath(config.remote_compl_dir, "tmp")
     end
 
     utils.ensure_directory_exists(config.tmpdir)
@@ -947,7 +946,7 @@ local set_directories = function()
     vim.env.RNVIM_COMPLDIR = config.compldir
 
     -- Make the file name of files to be sourced
-    config.source_file = config.tmpdir .. "/Rsource-" .. vim.fn.getpid()
+    config.source_file = fs.joinpath(config.tmpdir, "Rsource-" .. vim.fn.getpid())
 end
 
 local check_readme = function()
@@ -1016,13 +1015,15 @@ local check_readme = function()
             "  - Line breaks are indicated by \\x14.",
         }
 
-        vim.fn.writefile(readme, config.compldir .. "/README")
+        vim.fn.writefile(readme, fs.joinpath(config.compldir, "README"))
     end
 end
 
 local do_common_global = function()
     config.uname = uv.os_uname().sysname
-    config.is_windows = config.uname:find("Windows", 1, true) ~= nil
+    config.is_windows = not not (
+        config.uname:lower():find("windows") or config.uname:lower():find("mingw")
+    ) -- in line with `vim.fs`
     if config.r_ls.doc_width == 0 then
         local dw = vim.o.columns / 2 - 4
         if dw < 30 then dw = 30 end
@@ -1126,17 +1127,19 @@ end
 --- Install the "rout" parser, required to properly highlight R output in
 --- hover and resolve windows from the language server
 local check_rout_parser = function()
-    local routp = config.rnvim_home .. "/parser/rout.so"
-    local mt1 = mtime(config.rnvim_home .. "/resources/tree-sitter-rout/grammar.js")
+    local routp = fs.joinpath(config.rnvim_home, "parser/rout.so")
+    local mt1 =
+        mtime(fs.joinpath(config.rnvim_home, "resources/tree-sitter-rout/grammar.js"))
     local mt2 = mtime(routp)
     if mt1 and mt2 and mt2 > mt1 then return end
     if vim.fn.executable("tree-sitter") == 0 then return end
 
-    local _, err = vim.uv.fs_mkdir(config.rnvim_home .. "/parser", tonumber("755", 8))
+    local _, err =
+        vim.uv.fs_mkdir(fs.joinpath(config.rnvim_home, "parser"), tonumber("755", 8))
     if err and not err:find("EEXIST") then return end
 
     local cwdir = vim.uv.cwd()
-    vim.uv.chdir(config.rnvim_home .. "/resources/tree-sitter-rout")
+    vim.uv.chdir(fs.joinpath(config.rnvim_home, "resources/tree-sitter-rout"))
     -- from nvim-treesitter
     local obj = vim.system({ "tree-sitter", "generate" }, { text = true }):wait(3000)
     if obj.code ~= 0 then
@@ -1295,7 +1298,7 @@ M.real_setup = function()
 
     local bufname = vim.api.nvim_buf_get_name(0)
     if bufname ~= "" then
-        local rnc = vim.fs.joinpath(vim.fs.dirname(bufname), "rnvim_config.lua")
+        local rnc = fs.joinpath(fs.dirname(bufname), "rnvim_config.lua")
         if vim.uv.fs_access(rnc, "R") then
             local opts = dofile(rnc)
             apply_user_opts(opts)
@@ -1356,17 +1359,14 @@ M.check_health = function()
 
     -- Check if treesitter is available
     local function has_parser(parser_name, parsers)
-        local path = "parser" .. (config.is_windows and "\\" or "/") .. parser_name .. "."
+        local path = "parser/" .. parser_name .. "."
         for _, v in pairs(parsers) do
             if v:find(path, 1, true) then return true end
         end
         return false
     end
 
-    local parsers = vim.api.nvim_get_runtime_file(
-        "parser" .. (config.is_windows and "\\" or "/") .. "*.*",
-        true
-    )
+    local parsers = vim.api.nvim_get_runtime_file("parser/*", true) -- uses and returns forward-slashed paths despite the platform
 
     local needed = { "r" }
     if vim.tbl_contains({ "rmd", "quarto", "rnoweb", "typst" }, vim.bo.filetype) then

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -1115,11 +1115,11 @@ local do_common_global = function()
 end
 
 local mtime = function(fname)
-    local fd = vim.uv.fs_open(fname, "r", tonumber("644", 8))
+    local fd = uv.fs_open(fname, "r", tonumber("644", 8))
     local mt
     if fd then
-        mt = vim.uv.fs_fstat(fd).mtime.sec
-        vim.uv.fs_close(fd)
+        mt = uv.fs_fstat(fd).mtime.sec
+        uv.fs_close(fd)
     end
     return mt
 end
@@ -1135,11 +1135,11 @@ local check_rout_parser = function()
     if vim.fn.executable("tree-sitter") == 0 then return end
 
     local _, err =
-        vim.uv.fs_mkdir(fs.joinpath(config.rnvim_home, "parser"), tonumber("755", 8))
+        uv.fs_mkdir(fs.joinpath(config.rnvim_home, "parser"), tonumber("755", 8))
     if err and not err:find("EEXIST") then return end
 
-    local cwdir = vim.uv.cwd()
-    vim.uv.chdir(fs.joinpath(config.rnvim_home, "resources/tree-sitter-rout"))
+    local cwdir = uv.cwd()
+    uv.chdir(fs.joinpath(config.rnvim_home, "resources/tree-sitter-rout"))
     -- from nvim-treesitter
     local obj = vim.system({ "tree-sitter", "generate" }, { text = true }):wait(3000)
     if obj.code ~= 0 then
@@ -1151,7 +1151,7 @@ local check_rout_parser = function()
         swarn("Error building tree-sitter parser for `rout`: " .. obj.stderr)
         return
     end
-    if cwdir then vim.uv.chdir(cwdir) end
+    if cwdir then uv.chdir(cwdir) end
 end
 
 local global_setup = function()
@@ -1299,7 +1299,7 @@ M.real_setup = function()
     local bufname = vim.api.nvim_buf_get_name(0)
     if bufname ~= "" then
         local rnc = fs.joinpath(fs.dirname(bufname), "rnvim_config.lua")
-        if vim.uv.fs_access(rnc, "R") then
+        if uv.fs_access(rnc, "R") then
             local opts = dofile(rnc)
             apply_user_opts(opts)
         end

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -965,7 +965,7 @@ local check_readme = function()
         local l = vim.fn.split(vim.fn.glob(config.compldir .. "/*"), "\n")
         if #l > 0 then
             for _, f in ipairs(l) do
-                vim.fn.delete(f)
+                vim.fs.rm(f, { force = true })
             end
         end
 

--- a/lua/r/config.lua
+++ b/lua/r/config.lua
@@ -468,6 +468,7 @@ local hooks = require("r.hooks")
 ---@class RConfig: RConfigUserOpts
 ---@field uname? string
 ---@field is_windows? boolean
+---@field is_mingw? boolean
 ---@field rnvim_home? string
 ---@field uservimfiles? string
 ---@field user_login? string
@@ -697,7 +698,7 @@ local set_pdf_viewer = function()
         if config.skim_app_path == "" then
             config.skim_app_path = "/Applications/Skim.app"
         end
-    elseif config.is_windows then
+    elseif config.is_windows and not config.is_mingw then
         config.pdfviewer = "sumatra"
     else
         config.pdfviewer = "zathura"
@@ -883,10 +884,10 @@ local set_directories = function()
         swarn("Could not determine user name.")
     end
 
-    vim.env.RNVIM_HOME = rndir
+    vim.env.RNVIM_HOME = config.rnvim_home
 
     if config.compldir ~= "" then
-        config.compldir = fs.normalize(config.compldir)
+        config.compldir = vim.fn.expand(config.compldir)
     elseif config.is_windows and vim.env.APPDATA then
         config.compldir = fs.joinpath(vim.env.APPDATA, "R.nvim")
     elseif vim.env.XDG_CACHE_HOME then
@@ -902,7 +903,7 @@ local set_directories = function()
     utils.ensure_directory_exists(config.compldir)
 
     -- Check if the 'config' table has the key 'tmpdir'
-    if not config.tmpdir ~= "" then
+    if config.tmpdir == "" then
         local suffix = "R.nvim-" .. config.user_login
         local base
         -- Set temporary directory based on the platform
@@ -1021,9 +1022,8 @@ end
 
 local do_common_global = function()
     config.uname = uv.os_uname().sysname
-    config.is_windows = not not (
-        config.uname:lower():find("windows") or config.uname:lower():find("mingw")
-    ) -- in line with `vim.fs`
+    config.is_mingw = not not config.uname:lower():find("mingw")
+    config.is_windows = not not (config.uname:lower():find("windows") or config.is_mingw) -- in line with `vim.fs`
     if config.r_ls.doc_width == 0 then
         local dw = vim.o.columns / 2 - 4
         if dw < 30 then dw = 30 end
@@ -1095,7 +1095,7 @@ local do_common_global = function()
     end
 
     -- Set the name of R executable
-    if config.is_windows then
+    if config.is_windows and not config.is_mingw then
         config.R_app = "Rterm.exe"
         config.R_cmd = "R.exe"
     end
@@ -1188,7 +1188,7 @@ local global_setup = function()
     -- See https://github.com/jalvesaq/Vim-R/issues/625
     do_common_global()
 
-    if config.is_windows then
+    if config.is_windows and not config.is_mingw then
         require("r.platform.windows").configure(config)
     else
         require("r.platform.unix").configure(config)

--- a/lua/r/doc.lua
+++ b/lua/r/doc.lua
@@ -189,7 +189,7 @@ end
 M.load_html = function(fullpath, browser)
     if config.open_html == "no" then return end
 
-    local fname = fullpath:gsub(".*/", "")
+    local fname = vim.fs.basename(fullpath)
     if job.is_running(fullpath) then
         if config.open_html:find("focus") then
             utils.focus_window(fname, job.get_pid(fullpath))

--- a/lua/r/edit.lua
+++ b/lua/r/edit.lua
@@ -134,7 +134,7 @@ M.vim_leave = function()
     end
 
     for _, fn in pairs(del_list) do
-        vim.fn.delete(fn)
+        vim.fs.rm(fn, { force = true })
     end
 
     if config.remote_R_host == "" then
@@ -501,7 +501,7 @@ M.open_example = function()
     vim.api.nvim_set_option_value("bufhidden", "wipe", { scope = "local" })
     vim.api.nvim_set_option_value("swapfile", false, { scope = "local" })
     vim.api.nvim_set_option_value("buftype", "nofile", { scope = "local" })
-    vim.fn.delete(config.tmpdir .. "/example.R")
+    vim.fs.rm(vim.fs.joinpath(config.tmpdir, "example.R"), { force = true })
 end
 
 return M

--- a/lua/r/edit.lua
+++ b/lua/r/edit.lua
@@ -448,7 +448,7 @@ M.view_df = function(oname, txt)
     if config.view_df.save_fun and config.view_df.save_fun ~= "" then
         tsvnm = txt
     else
-        tsvnm = config.tmpdir .. "/" .. oname .. ".tsv"
+        tsvnm = vim.fs.joinpath(config.tmpdir, oname .. ".tsv")
         vim.fn.writefile(csv_lines, tsvnm)
     end
     M.add_for_deletion(tsvnm)
@@ -480,21 +480,28 @@ end
 M.open_example = function()
     local bl = vim.api.nvim_list_bufs()
     for _, v in pairs(bl) do
-        if vim.api.nvim_buf_get_name(v) == config.tmpdir .. "/example.R" then
+        if
+            vim.fs.normalize(vim.api.nvim_buf_get_name(v))
+            == vim.fs.joinpath(config.tmpdir, "example.R")
+        then
             vim.cmd("bunload! " .. tostring(v))
             break
         end
     end
 
     if config.nvimpager == "tabnew" or config.nvimpager == "tab" then
-        vim.cmd("tabnew " .. config.tmpdir:gsub(" ", "\\ ") .. "/example.R")
+        vim.cmd("tabnew " .. vim.fs.joinpath(config.tmpdir:gsub(" ", "\\ "), "example.R"))
     else
         if config.nvimpager == "split_v" then
             vim.cmd(
-                "belowright vsplit " .. config.tmpdir:gsub(" ", "\\ ") .. "/example.R"
+                "belowright vsplit "
+                    .. vim.fs.joinpath(config.tmpdir:gsub(" ", "\\ "), "example.R")
             )
         else
-            vim.cmd("belowright split " .. config.tmpdir:gsub(" ", "\\ ") .. "/example.R")
+            vim.cmd(
+                "belowright split "
+                    .. vim.fs.joinpath(config.tmpdir:gsub(" ", "\\ "), "example.R")
+            )
         end
     end
     vim.api.nvim_buf_set_keymap(0, "n", "q", ":q<CR>", { noremap = true, silent = true })

--- a/lua/r/edit.lua
+++ b/lua/r/edit.lua
@@ -490,17 +490,17 @@ M.open_example = function()
     end
 
     if config.nvimpager == "tabnew" or config.nvimpager == "tab" then
-        vim.cmd("tabnew " .. vim.fs.joinpath(config.tmpdir:gsub(" ", "\\ "), "example.R"))
+        vim.cmd("tabnew " .. vim.fs.joinpath(config.tmpdir, "example.R"):gsub(" ", "\\ "))
     else
         if config.nvimpager == "split_v" then
             vim.cmd(
                 "belowright vsplit "
-                    .. vim.fs.joinpath(config.tmpdir:gsub(" ", "\\ "), "example.R")
+                    .. vim.fs.joinpath(config.tmpdir, "example.R"):gsub(" ", "\\ ")
             )
         else
             vim.cmd(
                 "belowright split "
-                    .. vim.fs.joinpath(config.tmpdir:gsub(" ", "\\ "), "example.R")
+                    .. vim.fs.joinpath(config.tmpdir, "example.R"):gsub(" ", "\\ ")
             )
         end
     end

--- a/lua/r/lsp/quarto.lua
+++ b/lua/r/lsp/quarto.lua
@@ -51,7 +51,8 @@ local find_quarto_intel_windows = function(qpath2)
 end
 
 local find_quarto_intel = function()
-    local is_windows = vim.loop.os_uname().sysname:find("Windows") ~= nil
+    local uname = vim.loop.os_uname().sysname:lower()
+    local is_windows = not not (uname:find("windows") or uname:find("mingw"))
     local qpath2 = "/share/editor/tools/yaml/yaml-intelligence-resources.json"
     if is_windows then return find_quarto_intel_windows(qpath2) end
     return find_quarto_intel_unix(qpath2)

--- a/lua/r/pdf/init.lua
+++ b/lua/r/pdf/init.lua
@@ -71,12 +71,13 @@ M.open = function(fullpath)
 
     if fullpath == "Get Master" then
         local fpath = require("r.rnw").SyncTeX_get_master() .. ".pdf"
-        fpath = vim.b.rplugin_pdfdir .. "/" .. fpath:gsub(".*/", "")
+        fpath = vim.fs.joinpath(vim.b.rplugin_pdfdir, vim.fs.basename(fpath))
         M.open(fpath)
         return
     end
 
-    local fname = fullpath:gsub(".*/", "")
+    local fname = vim.fs.basename(fullpath)
+
     if job.is_running(fullpath) then
         if config.open_pdf:find("focus") then
             utils.focus_window(fname, job.get_pid(fullpath))

--- a/lua/r/pdf/sumatra.lua
+++ b/lua/r/pdf/sumatra.lua
@@ -34,17 +34,17 @@ local M = {}
 M.open = function(fullpath)
     if not SumatraInPath() then return end
 
-    local pdir = fullpath:gsub("(.*)/.*", "%1")
-    local olddir = vim.fn.getcwd():gsub("\\", "/"):gsub(" ", "\\ ")
+    local pdir = vim.fs.dirname(fullpath)
+    local olddir = vim.fs.normalize(vim.fn.getcwd()):gsub(" ", "\\ ")
     vim.cmd("cd " .. pdir)
     vim.fn.writefile({
         'start SumatraPDF.exe -reuse-instance -inverse-search "rnvimserver.exe %%f %%l" "'
             .. fullpath
             .. '"',
-    }, config.tmpdir .. "/run_cmd.bat")
-    vim.system({ config.tmpdir .. "/run_cmd.bat" }, { detach = true })
+    }, vim.fs.joinpath(config.tmpdir, "run_cmd.bat"))
+    vim.system({ vim.fs.joinpath(config.tmpdir, "run_cmd.bat") }, { detach = true })
     vim.cmd("cd " .. olddir)
-    require("r.edit").add_for_deletion(config.tmpdir .. "/run_cmd.bat")
+    require("r.edit").add_for_deletion(vim.fs.joinpath(config.tmpdir, "run_cmd.bat"))
 end
 
 ---Send the SyncTeX forward command to Sumatra
@@ -55,10 +55,10 @@ M.SyncTeX_forward = function(tpath, ppath, texln)
     if not SumatraInPath() then return end
 
     -- Empty spaces must be removed from the rnoweb file name to get SyncTeX support with SumatraPDF.
-    local tname = tpath:gsub(".*/(.*)", "%1")
-    local tdir = tpath:gsub("(.*)/.*", "%1")
+    local tname = vim.fs.basename(tpath)
+    local tdir = vim.fs.dirname(tpath)
     local pname = ppath:gsub(tdir .. "/", "")
-    local olddir = vim.fn.getcwd():gsub("\\", "/"):gsub(" ", "\\ ")
+    local olddir = vim.fs.normalize(vim.fn.getcwd()):gsub(" ", "\\ ")
     vim.cmd("cd " .. tdir:gsub(" ", "\\ "))
     vim.fn.writefile({
         'start SumatraPDF.exe -reuse-instance -forward-search "'
@@ -68,10 +68,10 @@ M.SyncTeX_forward = function(tpath, ppath, texln)
             .. ' -inverse-search "rnvimserver.exe %%f %%l" "'
             .. pname
             .. '"',
-    }, config.tmpdir .. "/run_cmd.bat")
-    vim.system({ config.tmpdir .. "/run_cmd.bat" }, { detach = true })
+    }, vim.fs.joinpath(config.tmpdir, "run_cmd.bat"))
+    vim.system({ vim.fs.joinpath(config.tmpdir, "run_cmd.bat") }, { detach = true })
     vim.cmd("cd " .. olddir)
-    require("r.edit").add_for_deletion(config.tmpdir .. "/run_cmd.bat")
+    require("r.edit").add_for_deletion(vim.fs.joinpath(config.tmpdir, "run_cmd.bat"))
 end
 
 return M

--- a/lua/r/rdoc.lua
+++ b/lua/r/rdoc.lua
@@ -69,7 +69,7 @@ M.fix_rdoc = function(txt)
     txt = string.gsub(txt, "<email: %([^>]*%)>", " |%1|")
     if not config.is_windows or config.is_mingw then
         -- curly single quotes only if the environment is UTF-8
-        txt = string.gsub(txt, "\145", "’")
+        txt = string.gsub(txt, "\145", "‘")
         txt = string.gsub(txt, "\146", "’")
     end
 

--- a/lua/r/rdoc.lua
+++ b/lua/r/rdoc.lua
@@ -67,9 +67,9 @@ M.fix_rdoc = function(txt)
     txt = string.gsub(txt, "\018", "\\")
     txt = string.gsub(txt, "<URL: %([^>]*%)>", " |%1|")
     txt = string.gsub(txt, "<email: %([^>]*%)>", " |%1|")
-    if not config.is_windows then
+    if not config.is_windows or config.is_mingw then
         -- curly single quotes only if the environment is UTF-8
-        txt = string.gsub(txt, "\145", "‘")
+        txt = string.gsub(txt, "\145", "’")
         txt = string.gsub(txt, "\146", "’")
     end
 

--- a/lua/r/run.lua
+++ b/lua/r/run.lua
@@ -2,7 +2,6 @@ local M = {}
 local config = require("r.config").get_config()
 local edit = require("r.edit")
 local warn = require("r.log").warn
-local utils = require("r.utils")
 local send = require("r.send")
 local cursor = require("r.cursor")
 local hooks = require("r.hooks")
@@ -22,7 +21,7 @@ local get_R_start_dir = function()
         rsd = M.get_buf_dir()
     elseif config.setwd == "nvim" then
         rsd = uv.cwd()
-        if rsd and config.is_windows then rsd = rsd:gsub("\\", "/") end
+        if rsd then rsd = vim.fs.normalize(rsd) end
     end
     return rsd
 end
@@ -41,16 +40,16 @@ start_R2 = function()
         end)
     end
 
-    vim.fn.writefile({}, config.tmpdir .. "/globenv_" .. vim.env.RNVIM_ID)
-    vim.fn.writefile({}, config.tmpdir .. "/liblist_" .. vim.env.RNVIM_ID)
+    vim.fn.writefile({}, vim.fs.joinpath(config.tmpdir, "globenv_" .. vim.env.RNVIM_ID))
+    vim.fn.writefile({}, vim.fs.joinpath(config.tmpdir, "liblist_" .. vim.env.RNVIM_ID))
 
-    edit.add_for_deletion(config.tmpdir .. "/globenv_" .. vim.env.RNVIM_ID)
-    edit.add_for_deletion(config.tmpdir .. "/liblist_" .. vim.env.RNVIM_ID)
+    edit.add_for_deletion(vim.fs.joinpath(config.tmpdir, "globenv_" .. vim.env.RNVIM_ID))
+    edit.add_for_deletion(vim.fs.joinpath(config.tmpdir, "liblist_" .. vim.env.RNVIM_ID))
 
     if vim.o.encoding == "utf-8" then
-        edit.add_for_deletion(config.tmpdir .. "/start_options_utf8.R")
+        edit.add_for_deletion(vim.fs.joinpath(config.tmpdir, "start_options_utf8.R"))
     else
-        edit.add_for_deletion(config.tmpdir .. "/start_options.R")
+        edit.add_for_deletion(vim.fs.joinpath(config.tmpdir, "start_options.R"))
     end
 
     -- Required to make R load nvimcom without the need for the user to include
@@ -134,9 +133,12 @@ start_R2 = function()
     )
 
     if vim.o.encoding == "utf-8" then
-        vim.fn.writefile(start_options, config.tmpdir .. "/start_options_utf8.R")
+        vim.fn.writefile(
+            start_options,
+            vim.fs.joinpath(config.tmpdir, "start_options_utf8.R")
+        )
     else
-        vim.fn.writefile(start_options, config.tmpdir .. "/start_options.R")
+        vim.fn.writefile(start_options, vim.fs.joinpath(config.tmpdir, "start_options.R"))
     end
 
     if config.RStudio_cmd ~= "" then
@@ -265,7 +267,7 @@ end
 
 M.set_nvimcom_info = function(nvimcomversion, rpid, wid, r_info)
     local r_home_description =
-        vim.fn.readfile(config.rnvim_home .. "/nvimcom/DESCRIPTION")
+        vim.fn.readfile(vim.fs.joinpath(config.rnvim_home, "nvimcom/DESCRIPTION"))
     local current
     for _, v in pairs(r_home_description) do
         if v:find("Version: ") then current = v:sub(10) end
@@ -681,16 +683,14 @@ M.clear_all = function()
 end
 
 M.get_buf_dir = function()
-    local rwd = vim.api.nvim_buf_get_name(0)
-    if config.is_windows then rwd = utils.normalize_windows_path(rwd) end
-    rwd = rwd:gsub("(.*)/.*", "%1")
-    return rwd
+    local rwd = vim.fs.normalize(vim.api.nvim_buf_get_name(0))
+    return vim.fs.dirname(rwd)
 end
 
 ---Send to R the command to source all files in a directory
 ---@param dir string
 M.source_dir = function(dir)
-    if config.is_windows then dir = utils.normalize_windows_path(dir) end
+    dir = vim.fs.normalize(dir)
     if dir == "" then
         send.cmd("nvim.srcdir()")
     else

--- a/lua/r/run.lua
+++ b/lua/r/run.lua
@@ -340,8 +340,14 @@ M.set_nvimcom_info = function(nvimcomversion, rpid, wid, r_info)
 end
 
 M.clear_R_info = function()
-    vim.fn.delete(config.tmpdir .. "/globenv_" .. vim.fn.string(vim.env.RNVIM_ID))
-    vim.fn.delete(config.tmpdir .. "/liblist_" .. vim.fn.string(vim.env.RNVIM_ID))
+    vim.fs.rm(
+        vim.fs.joinpath(config.tmpdir, "globenv_" .. vim.fn.string(vim.env.RNVIM_ID)),
+        { force = true }
+    )
+    vim.fs.rm(
+        vim.fs.joinpath(config.tmpdir, "liblist_" .. vim.fn.string(vim.env.RNVIM_ID)),
+        { force = true }
+    )
     R_pid = 0
     if config.external_term == "" then require("r.term.builtin").close_term() end
     if vim.g.R_Nvim_status > 3 then

--- a/lua/r/run.lua
+++ b/lua/r/run.lua
@@ -156,7 +156,7 @@ start_R2 = function()
         if vim.fn.executable("wezterm") == 1 then
             config.external_term = "wezterm"
         else
-            if config.is_windows then
+            if config.is_windows and not config.is_mingw then
                 warn("WezTerm must be installed to run R in a external terminal emulator")
                 return
             end

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -412,7 +412,7 @@ M.source_file = function()
         edit.add_for_deletion(fpath)
         local sargs = M.get_source_args()
         local ok = M.cmd('nvimcom:::source.and.clean("' .. fpath .. '"' .. sargs .. ")")
-        if not ok then vim.fn.delete(fpath) end
+        if not ok then vim.fs.rm(fpath, { force = true }) end
         return
     end
 

--- a/lua/r/send.lua
+++ b/lua/r/send.lua
@@ -387,6 +387,7 @@ end
 
 M.source_file = function()
     local fpath = vim.api.nvim_buf_get_name(0) .. ".tmp.R"
+    fpath = vim.fs.normalize(fpath)
 
     if vim.fn.filereadable(fpath) == 1 then
         warn(
@@ -396,8 +397,6 @@ M.source_file = function()
         )
         return
     end
-
-    if config.is_windows then fpath = utils.normalize_windows_path(fpath) end
 
     local lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
 

--- a/lua/r/server.lua
+++ b/lua/r/server.lua
@@ -102,7 +102,7 @@ end
 local start_rnvimserver = function()
     if vim.g.R_Nvim_status > 1 then return end
 
-    local rns_dir = config.rnvim_home .. "/rnvimserver"
+    local rns_dir = vim.fs.joinpath(config.rnvim_home, "rnvimserver")
 
     -- Some pdf viewers run rnvimserver to send SyncTeX messages back to Neovim
     if config.is_windows then
@@ -181,8 +181,8 @@ local init_exit = function(_, data, _)
     edit.add_to_debug_info("before_rns.R stdout", table.concat(b_out, "\n"))
     b_err = {}
     b_out = {}
-    edit.add_for_deletion(config.tmpdir .. "/bo_code.R")
-    edit.add_for_deletion(config.tmpdir .. "/libnames_" .. vim.env.RNVIM_ID)
+    edit.add_for_deletion(vim.fs.joinpath(config.tmpdir, "bo_code.R"))
+    edit.add_for_deletion(vim.fs.joinpath(config.tmpdir, "libnames_" .. vim.env.RNVIM_ID))
     if #b_warn > 0 then
         local wrn = table.concat(b_warn, "\n")
         edit.add_to_debug_info("RInit Warning", wrn)
@@ -226,7 +226,10 @@ local list_libs_from_buffer = function()
         end
     end
     local libs = table.concat(flibs, ",") .. "#"
-    vim.fn.writefile({ libs }, config.tmpdir .. "/libnames_" .. vim.env.RNVIM_ID)
+    vim.fn.writefile(
+        { libs },
+        vim.fs.joinpath(config.tmpdir, "libnames_" .. vim.env.RNVIM_ID)
+    )
 end
 
 -- Add words to the completion list of :Rhelp
@@ -237,7 +240,7 @@ local fill_Rhelp_list = function()
     M.rhelp_list = {}
 
     for _, v in pairs(libs) do
-        local omf = config.compldir .. "/alias_" .. v
+        local omf = vim.fs.joinpath(config.compldir, "alias_" .. v)
 
         -- List of objects
         local olist = vim.fn.readfile(omf)
@@ -287,7 +290,7 @@ end
 
 M.check_nvimcom_version = function()
     local flines
-    local nvimcom_desc_path = config.rnvim_home .. "/nvimcom/DESCRIPTION"
+    local nvimcom_desc_path = vim.fs.joinpath(config.rnvim_home, "nvimcom/DESCRIPTION")
     local current = "0.0.0"
     local nvc_fn
 
@@ -302,8 +305,10 @@ M.check_nvimcom_version = function()
         local obj
         obj = vim.system({ "df" }, { text = true }):wait()
         if not obj.stdout:find(".cache/R.nvim") then
-            local _, err =
-                vim.uv.fs_mkdir(config.compldir .. "/remote", tonumber("755", 8))
+            local _, err = vim.uv.fs_mkdir(
+                vim.fs.joinpath(config.compldir, "remote"),
+                tonumber("755", 8)
+            )
             if err and not err:find("EEXIST") then
                 warn(err)
                 return
@@ -315,13 +320,16 @@ M.check_nvimcom_version = function()
                 "-o",
                 "sshfs_sync",
                 config.remote_R_host .. ":" .. config.remote_compl_dir,
-                config.compldir .. "/remote",
+                vim.fs.joinpath(config.compldir, "remote"),
             }, { text = true }):wait()
             if obj.code ~= 0 then
                 warn(obj.stderr)
                 return
             end
-            _, err = vim.uv.fs_mkdir(config.compldir .. "/remote/tmp", tonumber("755", 8))
+            _, err = vim.uv.fs_mkdir(
+                vim.fs.joinpath(config.compldir, "remote/tmp"),
+                tonumber("755", 8)
+            )
             if err and not err:find("EEXIST") then
                 warn(err)
                 return
@@ -334,13 +342,16 @@ M.check_nvimcom_version = function()
         )
         table.insert(
             flines,
-            "Sys.setenv(RNVIM_TMPDIR = '" .. config.remote_compl_dir .. "/tmp')"
+            "Sys.setenv(RNVIM_TMPDIR = '"
+                .. vim.fs.joinpath(config.remote_compl_dir, "tmp")
+                .. "')"
         )
         table.insert(flines, 'nvim_r_home <- "not needed"')
-        nvc_fn = config.compldir .. "/remote/nvimcom_" .. current .. ".tar.gz"
+        nvc_fn =
+            vim.fs.joinpath(config.compldir, "remote/nvimcom_" .. current .. ".tar.gz")
     else
         table.insert(flines, 'nvim_r_home <- "' .. config.rnvim_home .. '"')
-        nvc_fn = config.compldir .. "/nvimcom_" .. current .. ".tar.gz"
+        nvc_fn = vim.fs.joinpath(config.compldir, "nvimcom_" .. current .. ".tar.gz")
     end
 
     if vim.fn.filereadable(nvc_fn) == 0 then
@@ -379,14 +390,14 @@ M.check_nvimcom_version = function()
 
     vim.list_extend(
         flines,
-        vim.fn.readfile(config.rnvim_home .. "/resources/before_rns.R")
+        vim.fn.readfile(vim.fs.joinpath(config.rnvim_home, "resources/before_rns.R"))
     )
 
-    local scrptnm = config.tmpdir .. "/before_rns.R"
+    local scrptnm = vim.fs.joinpath(config.tmpdir, "before_rns.R")
     vim.fn.writefile(flines, scrptnm)
-    edit.add_for_deletion(config.tmpdir .. "/before_rns.R")
+    edit.add_for_deletion(vim.fs.joinpath(config.tmpdir, "before_rns.R"))
     if config.remote_R_host ~= "" then
-        scrptnm = config.remote_tmpdir .. "/before_rns.R"
+        scrptnm = vim.fs.joinpath(config.remote_tmpdir, "before_rns.R")
     end
 
     -- Run the script as a job, setting callback functions to receive its
@@ -424,13 +435,15 @@ M.build_cache_files = function()
         table.insert(
             Rcode,
             1,
-            "Sys.setenv(RNVIM_TMPDIR = '" .. config.remote_compl_dir .. "/tmp')"
+            "Sys.setenv(RNVIM_TMPDIR = '"
+                .. vim.fs.joinpath(config.remote_compl_dir, "tmp")
+                .. "')"
         )
     end
-    local scrptnm = config.tmpdir .. "/bo_code.R"
+    local scrptnm = vim.fs.joinpath(config.tmpdir, "bo_code.R")
     vim.fn.writefile(Rcode, scrptnm)
     if config.remote_R_host ~= "" then
-        scrptnm = config.remote_compl_dir .. "/tmp/bo_code.R"
+        scrptnm = vim.fs.joinpath(config.remote_compl_dir, "tmp/bo_code.R")
     end
     local opts = {
         on_stdout = init_stdout,
@@ -450,8 +463,11 @@ end
 
 -- Called by rnvimserver when it gets an error running R code
 M.show_bol_error = function(stt)
-    if vim.fn.filereadable(config.tmpdir .. "/run_R_stderr") == 1 then
-        local ferr = table.concat(vim.fn.readfile(config.tmpdir .. "/run_R_stderr"), "\n")
+    if vim.fn.filereadable(vim.fs.joinpath(config.tmpdir, "run_R_stderr")) == 1 then
+        local ferr = table.concat(
+            vim.fn.readfile(vim.fs.joinpath(config.tmpdir, "run_R_stderr")),
+            "\n"
+        )
         local errmsg = "Exit status: " .. stt .. "\n" .. ferr
         if
             ferr:find("Error in library..nvimcom...*there is no package called .*nvimcom")
@@ -461,7 +477,7 @@ M.show_bol_error = function(stt)
         end
         edit.add_to_debug_info("Error running R code", errmsg)
         warn("Error building objls_ file. Run :RDebugInfo for details.")
-        vim.fs.rm(config.tmpdir .. "/run_R_stderr", { force = true })
+        vim.fs.rm(vim.fs.joinpath(config.tmpdir, "run_R_stderr"), { force = true })
     else
         warn(config.tmpdir .. "/run_R_stderr not found")
     end

--- a/lua/r/server.lua
+++ b/lua/r/server.lua
@@ -150,8 +150,8 @@ local start_rnvimserver = function()
 
     if config.is_windows then require("r.windows").unset_R_home() end
 
-    edit.add_for_deletion(config.tmpdir .. "/run_R_stdout")
-    edit.add_for_deletion(config.tmpdir .. "/run_R_stderr")
+    edit.add_for_deletion(vim.fs.joinpath(config.tmpdir, "run_R_stdout"))
+    edit.add_for_deletion(vim.fs.joinpath(config.tmpdir, "run_R_stderr"))
 
     vim.api.nvim_create_user_command("RGetNRSInfo", require("r.server").echo_rns_info, {})
 end

--- a/lua/r/server.lua
+++ b/lua/r/server.lua
@@ -461,7 +461,7 @@ M.show_bol_error = function(stt)
         end
         edit.add_to_debug_info("Error running R code", errmsg)
         warn("Error building objls_ file. Run :RDebugInfo for details.")
-        vim.fn.delete(config.tmpdir .. "/run_R_stderr")
+        vim.fs.rm(config.tmpdir .. "/run_R_stderr", { force = true })
     else
         warn(config.tmpdir .. "/run_R_stderr not found")
     end

--- a/lua/r/server.lua
+++ b/lua/r/server.lua
@@ -105,7 +105,7 @@ local start_rnvimserver = function()
     local rns_dir = vim.fs.joinpath(config.rnvim_home, "rnvimserver")
 
     -- Some pdf viewers run rnvimserver to send SyncTeX messages back to Neovim
-    if config.is_windows then
+    if config.is_windows and not config.is_mingw then
         vim.env.PATH = rns_dir .. ";" .. vim.env.PATH
     else
         vim.env.PATH = rns_dir .. ":" .. vim.env.PATH
@@ -143,12 +143,16 @@ local start_rnvimserver = function()
 
     -- We have to set R's home directory on Windows because rnvimserver will
     -- run R to build the list for auto completion.
-    if config.is_windows then require("r.windows").set_R_home() end
+    if config.is_windows and not config.is_mingw then
+        require("r.windows").set_R_home()
+    end
 
     vim.g.R_Nvim_status = 2
     require("r.lsp").start(rns_env)
 
-    if config.is_windows then require("r.windows").unset_R_home() end
+    if config.is_windows and not config.is_mingw then
+        require("r.windows").unset_R_home()
+    end
 
     edit.add_for_deletion(vim.fs.joinpath(config.tmpdir, "run_R_stdout"))
     edit.add_for_deletion(vim.fs.joinpath(config.tmpdir, "run_R_stderr"))
@@ -355,7 +359,8 @@ M.check_nvimcom_version = function()
     end
 
     if vim.fn.filereadable(nvc_fn) == 0 then
-        local oldf = vim.fn.glob("~/.cache/R.nvim/nvimcom_*.tar.gz", true, true)
+        local oldf =
+            vim.fn.glob(vim.fs.joinpath(config.compldir, "nvimcom_*.tar.gz"), true, true)
         for _, o in ipairs(oldf) do
             vim.uv.fs_unlink(o)
         end

--- a/lua/r/yaml.lua
+++ b/lua/r/yaml.lua
@@ -10,8 +10,9 @@ M.setup = function()
     if vim.fn.executable("yaml-language-server") == 0 then return end
 
     local plugin_root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":h:h:h")
-    local document_schema = plugin_root .. "/resources/quarto-schema.json"
-    local project_schema = plugin_root .. "/resources/quarto-project-schema.json"
+    local document_schema = vim.fs.joinpath(plugin_root, "resources/quarto-schema.json")
+    local project_schema =
+        vim.fs.joinpath(plugin_root, "resources/quarto-project-schema.json")
 
     local yaml_settings = {
         yaml = {

--- a/tests/test_workspace_symbols_spec.lua
+++ b/tests/test_workspace_symbols_spec.lua
@@ -182,7 +182,7 @@ describe("LSP workspace symbols", function()
 
         after_each(function()
             if find_files_stub then find_files_stub:revert() end
-            if tmpfile then vim.fn.delete(tmpfile) end
+            if tmpfile then vim.fs.rm(tmpfile, { force = true }) end
             package.loaded["r.lsp.workspace"] = nil
         end)
 


### PR DESCRIPTION
this PR aims to unify path manipulation around the codebase both to ensure consistency and compatibility on all platforms using `vim.fs` and `vim.uv` function where appropriate. 

i'll make commits limited to files or in larger batches to make debugging and reviewing easier.