### PR TITLE
fix(bol.R): set num_cores to 1 on Windows to prevent parallel execution issues (closes #603)

### DIFF
--- a/nvimcom/R/bol.R
+++ b/nvimcom/R/bol.R
@@ -695,6 +695,11 @@ nvim.build.cmplls <- function() {
     } else {
         num_cores <- getOption("nvimcom.max_cpu_cores")
     }
+
+    if (.Platform$OS.type == "windows") {
+        num_cores <- 1
+    }
+
     invisible(parallel::mclapply(1:nrow(b), process_row, mc.cores = num_cores))
 
     return(invisible(0))


### PR DESCRIPTION
`parallel::mclapply` does not seem to be working on Windows, so we force the number of cores to be 1.