### PR TITLE
fix(flake): compile rnvimserver when building the Nix package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -85,6 +85,12 @@
           pname = "R.nvim";
           version = "0.1.0";
           src = ./.;
+          nativeBuildInputs = [pkgs.gnumake pkgs.gcc];
+          buildPhase = ''
+            runHook preBuild
+            make -C rnvimserver
+            runHook postBuild
+          '';
         };
       }
     );


### PR DESCRIPTION
Hi,

This at least partially fixes #595.

This PR resolves the `rnvimserver` part of the issue: the binary is now compiled at build time, instead of relying on Neovim to compile it at runtime (which doesn't work well on NixOS, since the Nix store is read-only).

The package can then be consumed via, e.g.:

```nix
inputs.plugins-rNvim.packages.${pkgs.stdenv.hostPlatform.system}.default
```

with `rnvimserver` already baked in.

`nvimcom` still requires a bit of extra tinkering, but I could open a separate PR to also expose `nvimcom` as its own Nix package for easier downstream integration.

All the best,
Neurarian

