### PR TITLE
feat(flake): expose nvimcom as a standalone package output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,17 +80,29 @@
           '';
         };
 
-        # Optional: Add a package for R.nvim itself
-        packages.default = pkgs.vimUtils.buildVimPlugin {
-          pname = "R.nvim";
-          version = "0.1.0";
-          src = ./.;
-          nativeBuildInputs = [pkgs.gnumake pkgs.gcc];
-          buildPhase = ''
-            runHook preBuild
-            make -C rnvimserver
-            runHook postBuild
-          '';
+        packages = let
+          nativeBuildInputs = with pkgs; [gnumake gcc];
+        in {
+          # Optional: Add a package for R.nvim itself
+          default = pkgs.vimUtils.buildVimPlugin {
+            pname = "R.nvim";
+            version = "1.0.0";
+            src = ./.;
+            inherit nativeBuildInputs;
+            buildPhase = ''
+              runHook preBuild
+              make -C rnvimserver
+              runHook postBuild
+            '';
+          };
+
+          # Separate nvimcom R package
+          nvimcom = pkgs.rPackages.buildRPackage {
+            name = "nvimcom";
+            version = "0.9.96";
+            src = ./nvimcom;
+            inherit nativeBuildInputs;
+          };
         };
       }
     );


### PR DESCRIPTION
As mentioned in https://github.com/R-nvim/R.nvim/pull/615 , this PR would add an opt-in flake output for users who also want to manage `nvimcom` declaratively through Nix. For example, baked into a

```nix
rWrapper.override { packages = [...] }
``` 
set ahead of time. This is particularly useful for use with `rix` which doesn't allow installing R packages at runtime.

Depending on how the input is defined, it would be consumed via:

```nix
inputs.plugins-rNvim.packages.${pkgs.stdenv.hostPlatform.system}.nvimcom
```
Best,
Neurarian