### PR TITLE
fix(term): delete orphan buffer created when reopening the R console

### DIFF
--- a/lua/r/term/builtin.lua
+++ b/lua/r/term/builtin.lua
@@ -107,7 +107,7 @@ M.reopen_win = function()
     split_window()
     local orphan = vim.api.nvim_get_current_buf()
     vim.api.nvim_win_set_buf(0, r_bufnr)
-    vim.api.nvim_buf_delete(orphan, { force = true })
+    pcall(vim.api.nvim_buf_delete, orphan, { force = true })
     vim.cmd.sb(edbuf)
 end
 

--- a/lua/r/term/builtin.lua
+++ b/lua/r/term/builtin.lua
@@ -105,7 +105,9 @@ M.reopen_win = function()
     end
     local edbuf = vim.api.nvim_get_current_buf()
     split_window()
+    local orphan = vim.api.nvim_get_current_buf()
     vim.api.nvim_win_set_buf(0, r_bufnr)
+    vim.api.nvim_buf_delete(orphan, { force = true })
     vim.cmd.sb(edbuf)
 end
 


### PR DESCRIPTION
If I open the R console, then hide it (e.g. with ^W^O), and then reopen it, a phantom/orphaned [No Name] buffer is created. Is that a feature or a bug? 

Anyways, this PR is to delete those orphaned buffers :)