### PR TITLE
fix(send): fix RSendChain misdetecting pipe position in quarto/rmd files

### DIFF
--- a/lua/r/buffer.lua
+++ b/lua/r/buffer.lua
@@ -30,40 +30,36 @@ M.create_r_buffer = function()
          ]]
     )
 
-    local contents = {}
+    local lines = {}
     local last_end = 0
 
     local root = get_root_node(bufnr)
     if not root then return end
 
     for id, node in query:iter_captures(root, bufnr, 0, -1) do
-        local start_row, _, end_row, _ = node:range()
-
-        -- Replace non-R content with blank lines
-        for _ = last_end, start_row - 1 do
-            table.insert(contents, "")
-        end
-
-        -- Add R chunk content
         if query.captures[id] == "content" then
-            local chunk_content = vim.treesitter.get_node_text(node, bufnr)
+            local start_row, _, end_row, _ = node:range()
 
-            -- Account for the chunk delimiter
-            table.insert(contents, "")
-            table.insert(contents, chunk_content)
-            table.insert(contents, "")
+            -- Replace non-R content (including the chunk delimiters) with
+            -- blank lines
+            for _ = last_end, start_row - 1 do
+                table.insert(lines, "")
+            end
+
+            vim.list_extend(
+                lines,
+                vim.api.nvim_buf_get_lines(bufnr, start_row, end_row, false)
+            )
+
+            last_end = end_row
         end
-
-        last_end = end_row + 1
     end
 
     -- Replace remaining non-R content at the end with blank lines
     local buffer_line_count = vim.api.nvim_buf_line_count(bufnr)
     for _ = last_end, buffer_line_count - 1 do
-        table.insert(contents, "")
+        table.insert(lines, "")
     end
-
-    local lines = table.concat(contents, "\n")
 
     local rbuf = vim.api.nvim_create_buf(false, true)
 
@@ -72,7 +68,7 @@ M.create_r_buffer = function()
         return
     end
 
-    vim.api.nvim_buf_set_lines(rbuf, 0, -1, false, vim.split(lines, "\n"))
+    vim.api.nvim_buf_set_lines(rbuf, 0, -1, false, lines)
     vim.bo[rbuf].filetype = "r"
 
     return rbuf


### PR DESCRIPTION
I came around an issue with a long qmd document where extracted code chunk postions would become drifted by some lines in the temporary buffer we are creating to capture chunks. This caused an issue with `RSendChain` thinking that the cursor was not in a piped expression althought it was. This would give the folowing message:

```
The cursor is not inside a piped expression.
```

I found that `create_r_buffer()` used `get_node_text()` to copy R chunk content into the scratch buffer, but its handling of the trailing newline is inconsistent across Neovim versions, silently adding one extra blank line per chunk and misaligning row numbers on long documents. With some test, I found that `nvim_buf_get_lines()` is a better cross-version approach.

